### PR TITLE
Skip TestLookup test when networking is disabled

### DIFF
--- a/cmd/anubis/internal/dnsbl/dnsbl_test.go
+++ b/cmd/anubis/internal/dnsbl/dnsbl_test.go
@@ -3,6 +3,7 @@ package dnsbl
 import (
 	"fmt"
 	"net"
+	"os"
 	"testing"
 )
 
@@ -46,6 +47,11 @@ func TestReverse6(t *testing.T) {
 }
 
 func TestLookup(t *testing.T) {
+	if os.Getenv("DONT_USE_NETWORK") != "" {
+		t.Skip("test requires network egress")
+		return
+	}
+
 	resp, err := Lookup("27.65.243.194")
 	if err != nil {
 		t.Fatalf("it broked: %v", err)


### PR DESCRIPTION
This allows the tests to succeed in a build sandbox with no internet raccess

Checklist:

- [ ] Added a description of the changes to the `[Unreleased]` section of docs/docs/CHANGELOG.md
- [x] Tested this at least manually
