### PR TITLE
cmd/containerbuild: default to ttl.sh for third party contributions

### DIFF
--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -16,6 +16,7 @@ permissions:
   packages: write
   attestations: write
   id-token: write
+  pull-requests: write
 
 jobs:
   build:
@@ -56,6 +57,16 @@ jobs:
         id: build
         run: |
           go run ./cmd/containerbuild --docker-repo ghcr.io/techarohq/anubis --slog-level debug
+
+      - name: "Comment about where to test this"
+        uses: thollander/actions-comment-pull-request@v3
+        with:
+          message: |
+            You can try this PR out by using the following docker image:
+
+            ```
+            ${{ steps.build.outputs.docker_image }}
+            ```
       
       - name: Generate artifact attestation
         uses: actions/attest-build-provenance@v2

--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -67,6 +67,7 @@ jobs:
             ```
             ${{ steps.build.outputs.docker_image }}
             ```
+          comment-tag: ${{ steps.build.outputs.docker_image }}
       
       - name: Generate artifact attestation
         uses: actions/attest-build-provenance@v2


### PR DESCRIPTION
Closes #48

Default to using ttl.sh for contributions from outside the org, done via a simple needle/haystack member in list.

Checklist:

- [x] Tested this at least manually
