### PR TITLE
cmd/anubis: do not return error from sha256

### DIFF
--- a/cmd/anubis/main.go
+++ b/cmd/anubis/main.go
@@ -253,13 +253,10 @@ func metricsServer(ctx context.Context, done func()) {
 	}
 }
 
-func sha256sum(text string) (string, error) {
+func sha256sum(text string) string {
 	hash := sha256.New()
-	_, err := hash.Write([]byte(text))
-	if err != nil {
-		return "", err
-	}
-	return hex.EncodeToString(hash.Sum(nil)), nil
+	hash.Write([]byte(text))
+	return hex.EncodeToString(hash.Sum(nil))
 }
 
 func (s *Server) challengeFor(r *http.Request, difficulty int) string {
@@ -274,8 +271,7 @@ func (s *Server) challengeFor(r *http.Request, difficulty int) string {
 		fp,
 		difficulty,
 	)
-	result, _ := sha256sum(data)
-	return result
+	return sha256sum(data)
 }
 
 func New(target, policyFname string) (*Server, error) {
@@ -502,13 +498,7 @@ func (s *Server) maybeReverseProxy(w http.ResponseWriter, r *http.Request) {
 	}
 
 	calcString := fmt.Sprintf("%s%d", challenge, nonce)
-	calculated, err := sha256sum(calcString)
-	if err != nil {
-		lg.Error("failed to calculate sha256sum", "path", r.URL.Path, "err", err)
-		clearCookie(w)
-		http.Error(w, err.Error(), http.StatusInternalServerError)
-		return
-	}
+	calculated := sha256sum(calcString)
 
 	if subtle.ConstantTimeCompare([]byte(claims["response"].(string)), []byte(calculated)) != 1 {
 		lg.Debug("invalid response", "path", r.URL.Path)
@@ -598,13 +588,7 @@ func (s *Server) passChallenge(w http.ResponseWriter, r *http.Request) {
 	}
 
 	calcString := fmt.Sprintf("%s%d", challenge, nonce)
-	calculated, err := sha256sum(calcString)
-	if err != nil {
-		clearCookie(w)
-		lg.Debug("can't parse shasum", "err", err)
-		templ.Handler(base("Oh noes!", errorPage("failed to calculate sha256sum")), templ.WithStatus(http.StatusInternalServerError)).ServeHTTP(w, r)
-		return
-	}
+	calculated := sha256sum(calcString)
 
 	if subtle.ConstantTimeCompare([]byte(response), []byte(calculated)) != 1 {
 		clearCookie(w)

--- a/cmd/anubis/policy.go
+++ b/cmd/anubis/policy.go
@@ -46,7 +46,7 @@ func (b Bot) Hash() (string, error) {
 		userAgentRex = b.UserAgent.String()
 	}
 
-	return sha256sum(fmt.Sprintf("%s::%s::%s", b.Name, pathRex, userAgentRex))
+	return sha256sum(fmt.Sprintf("%s::%s::%s", b.Name, pathRex, userAgentRex)), nil
 }
 
 func parseConfig(fin io.Reader, fname string, defaultDifficulty int) (*ParsedConfig, error) {


### PR DESCRIPTION
hash.Write never returns error so removing it from the results simplifies usage and eliminates dead error handling.

<!-- delete me and describe your change here -->

Checklist:

- [ ] Added a description of the changes to the `[Unreleased]` section of docs/docs/CHANGELOG.md
- [x] Tested this at least manually
