### PR TITLE
fix: installation instructions and example

### DIFF
--- a/docs/docs/CHANGELOG.md
+++ b/docs/docs/CHANGELOG.md
@@ -11,6 +11,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+- Fixed and clarified installation instructions
+
 ## v1.14.2
 
 Livia sas Junius: Echo 2

--- a/docs/docs/admin/installation.mdx
+++ b/docs/docs/admin/installation.mdx
@@ -29,7 +29,7 @@ Anubis uses these environment variables for configuration:
 | `METRICS_BIND`         | `:9090`                    | The network address that Anubis serves Prometheus metrics on. See `BIND` for more information.                                                                                                                                                                                           |
 | `METRICS_BIND_NETWORK` | `tcp`                      | The address family that the Anubis metrics server listens on. See `BIND_NETWORK` for more information.                                                                                                                                                                                   |
 | `SOCKET_MODE`          | `0770`                     | *Only used when at least one of the `*_BIND_NETWORK` variables are set to `unix`.* The socket mode (permissions) for Unix domain sockets.                                                                                                                                                |
-| `POLICY_FNAME`         | `/data/cfg/botPolicy.json` | The file containing [bot policy configuration](./policies.md). See the bot policy documentation for more details.                                                                                                                                                                        |
+| `POLICY_FNAME`         | unset                      | The file containing [bot policy configuration](./policies.md). See the bot policy documentation for more details. If unset, the default bot policy configuration is used.                                                                                                                |
 | `SERVE_ROBOTS_TXT`     | `false`                    | If set `true`, Anubis will serve a default `robots.txt` file that disallows all known AI scrapers by name and then additionally disallows every scraper. This is useful if facts and circumstances make it difficult to change the underlying service to serve such a `robots.txt` file. |
 | `TARGET`               | `http://localhost:3923`    | The URL of the service that Anubis should forward valid requests to. Supports Unix domain sockets, set this to a URI like so: `unix:///path/to/socket.sock`.                                                                                                                             |
 
@@ -47,13 +47,15 @@ services:
       METRICS_BIND: ":9090"
       SERVE_ROBOTS_TXT: "true"
       TARGET: "http://nginx"
+      POLICY_FNAME: "/data/cfg/botPolicy.json"
     ports:
       - 8080:8080
+    volumes:
+      - "./botPolicy.json:/data/cfg/botPolicy.json:ro"
   nginx:
     image: nginx
     volumes:
       - "./www:/usr/share/nginx/html"
-      - "./botPolicy.json:/data/cfg/botPolicy.json"
 ```
 
 ## Kubernetes


### PR DESCRIPTION
I had some issues when following the installation guide. The file `/data/cfg/botPolicy.json` is not used automatically. After debugging I found that it is indeed not the default value for the environment variable, so I clarified the documentation.

Also, in the example the `botPolicy.json` is mounted into the `nginx` container, not the `anubis-nginx`, so that could not have worked anyway.

Checklist:

- [x] Added a description of the changes to the `[Unreleased]` section of docs/docs/CHANGELOG.md
- [x] Tested this at least manually
