### PR TITLE
cmd/anubis: amend generic browser challenge to "Gecko"

### DIFF
--- a/cmd/anubis/botPolicies.json
+++ b/cmd/anubis/botPolicies.json
@@ -390,7 +390,7 @@
     },
     {
       "name": "generic-browser",
-      "user_agent_regex": "(?i:gecko|applewebkit)",
+      "user_agent_regex": "(?i:gecko)",
       "action": "CHALLENGE"
     }
   ],

--- a/cmd/anubis/botPolicies.json
+++ b/cmd/anubis/botPolicies.json
@@ -390,7 +390,7 @@
     },
     {
       "name": "generic-browser",
-      "user_agent_regex": "Mozilla",
+      "user_agent_regex": "(?i:gecko|applewebkit)",
       "action": "CHALLENGE"
     }
   ],

--- a/docs/docs/CHANGELOG.md
+++ b/docs/docs/CHANGELOG.md
@@ -12,6 +12,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ## [Unreleased]
 
 - Fixed and clarified installation instructions
+- Changed default challenge logic for "Gecko" or "AppleWebkit" in the User-Agent string
+  instead of "Mozilla" [#78](https://github.com/TecharoHQ/anubis/pull/78)
 
 ## v1.14.2
 

--- a/docs/docs/CHANGELOG.md
+++ b/docs/docs/CHANGELOG.md
@@ -12,7 +12,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ## [Unreleased]
 
 - Fixed and clarified installation instructions
-- Changed default challenge logic for "Gecko" or "AppleWebkit" in the User-Agent string
+- Changed default challenge logic for "Gecko" in the User-Agent string
   instead of "Mozilla" [#78](https://github.com/TecharoHQ/anubis/pull/78)
 
 ## v1.14.2


### PR DESCRIPTION
I'm gonna be honest, this is an extreme galaxy brain strategy and I'm not entirely sure if this will pan out. However I got the idea when reading [a community post][0]

If this works, that would be so much funnier than just using "Mozilla" in the rules. I think that this could greatly backfire though, which is why I'm making a pull request and opening this for feedback from the community.

It would be absolutely hilarious if this works though.

[0]: https://github.com/TecharoHQ/anubis/discussions/68#discussioncomment-12583134

Checklist:

- [x] Added a description of the changes to the `[Unreleased]` section of docs/docs/CHANGELOG.md
- [x] Tested this at least manually
