### PR TITLE
cmd/anubis: do not apply bot rules if address check fails

### DIFF
--- a/cmd/anubis/policy.go
+++ b/cmd/anubis/policy.go
@@ -157,9 +157,11 @@ func cr(name string, rule config.Rule) CheckResult {
 	}
 }
 
+// checkRemoteAddress checks if the given IP address is within the expected range of the bot,
+// or if none applies.
 func (s *Server) checkRemoteAddress(b Bot, addr net.IP) bool {
 	if b.Ranger == nil {
-		return false
+		return true
 	}
 
 	ok, err := b.Ranger.Contains(addr)
@@ -184,13 +186,13 @@ func (s *Server) check(r *http.Request) (CheckResult, *Bot, error) {
 
 	for _, b := range s.policy.Bots {
 		if b.UserAgent != nil {
-			if uaMatch := b.UserAgent.MatchString(r.UserAgent()); uaMatch || (uaMatch && s.checkRemoteAddress(b, addr)) {
+			if b.UserAgent.MatchString(r.UserAgent()) && s.checkRemoteAddress(b, addr) {
 				return cr("bot/"+b.Name, b.Action), &b, nil
 			}
 		}
 
 		if b.Path != nil {
-			if pathMatch := b.Path.MatchString(r.URL.Path); pathMatch || (pathMatch && s.checkRemoteAddress(b, addr)) {
+			if b.Path.MatchString(r.URL.Path) && s.checkRemoteAddress(b, addr) {
 				return cr("bot/"+b.Name, b.Action), &b, nil
 			}
 		}

--- a/docs/docs/CHANGELOG.md
+++ b/docs/docs/CHANGELOG.md
@@ -12,6 +12,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ## [Unreleased]
 
 - Fixed and clarified installation instructions
+- Fixed bot check to only apply if address range matches
 
 ## v1.14.2
 


### PR DESCRIPTION
During the implementation of #81 I've noticed, that requests using the Kagibot User-Agent were `ALLOW`ed despite coming from an incorrect IP-range. This seems undesirable.

Given that the current conditionals include a check for the address that can never be triggered, I assume the intend is to actually check the range as well?

Checklist:

- [x] Added a description of the changes to the `[Unreleased]` section of docs/docs/CHANGELOG.md
- [x] Tested this at least manually
