### PR TITLE
Hide directory browsing on the static content

### DIFF
--- a/docs/docs/CHANGELOG.md
+++ b/docs/docs/CHANGELOG.md
@@ -11,6 +11,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+- Hide the directory listings for Anubis' internal static content
 - Changed `--debug-x-real-ip-default` to `--use-remote-address`, getting the IP address from the request's socket address instead.
 - DroneBL lookups have been disabled by default
 

--- a/internal/headers.go
+++ b/internal/headers.go
@@ -4,6 +4,7 @@ import (
 	"log/slog"
 	"net"
 	"net/http"
+	"strings"
 
 	"github.com/TecharoHQ/anubis"
 	"github.com/sebest/xff"
@@ -59,6 +60,17 @@ func XForwardedForToXRealIP(next http.Handler) http.Handler {
 			r.Header.Set("X-Real-Ip", ip)
 		}
 
+		next.ServeHTTP(w, r)
+	})
+}
+
+// Do not allow browsing directory listings in paths that end with /
+func NoBrowsing(next http.Handler) http.Handler {
+	return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if strings.HasSuffix(r.URL.Path, "/") {
+			http.NotFound(w, r)
+			return
+		}
 		next.ServeHTTP(w, r)
 	})
 }

--- a/lib/anubis.go
+++ b/lib/anubis.go
@@ -119,7 +119,7 @@ func New(opts Options) (*Server, error) {
 	mux := http.NewServeMux()
 	xess.Mount(mux)
 
-	mux.Handle(anubis.StaticPath, internal.UnchangingCache(http.StripPrefix(anubis.StaticPath, http.FileServerFS(web.Static))))
+	mux.Handle(anubis.StaticPath, internal.UnchangingCache(internal.NoBrowsing(http.StripPrefix(anubis.StaticPath, http.FileServerFS(web.Static)))))
 
 	if opts.ServeRobotsTXT {
 		mux.HandleFunc("/robots.txt", func(w http.ResponseWriter, r *http.Request) {


### PR DESCRIPTION
Demo: https://anubis.techaro.lol/.within.website/x/cmd/anubis/

![image](https://github.com/user-attachments/assets/8a023f48-5585-4daa-850f-e447e347346b)

Currently the embedded static content under the `/.within.website/x/cmd/anubis/` path on any Anubis-enabled site will serve all the content as browsable directories.

While the content itself is also accessible using normal means from the HTML code that loads the JavaScript files and images, for exmple, it is still an industry standard to disallow directory browsing on production websites, just to not give adversaries any possible hints as to what kinds of files are available on the server.

As it is now, the built-in `botPolicies.json` is also revealed in this listing. I'm not sure why it would even be necessary to have this data available on the client side? This PR does not address this issue, so the file will still be available, however the directory listings will not be shown.

PS. I'm not really experienced in Go and this solution was derived from some casual Googling.

Checklist:

- [x] Added a description of the changes to the `[Unreleased]` section of docs/docs/CHANGELOG.md
- [x] Tested this at least manually
