### PR TITLE
Change how to make Anubis work without a reverse proxy

### DIFF
--- a/cmd/anubis/main.go
+++ b/cmd/anubis/main.go
@@ -214,7 +214,7 @@ func main() {
 
 	var h http.Handler
 	h = s
-	h = internal.RemoteXRealIP(*useRemoteAddress, h)
+	h = internal.RemoteXRealIP(*useRemoteAddress, *bindNetwork, h)
 	h = internal.XForwardedForToXRealIP(h)
 
 	srv := http.Server{Handler: h}

--- a/cmd/anubis/main.go
+++ b/cmd/anubis/main.go
@@ -45,7 +45,7 @@ var (
 	slogLevel            = flag.String("slog-level", "INFO", "logging level (see https://pkg.go.dev/log/slog#hdr-Levels)")
 	target               = flag.String("target", "http://localhost:3923", "target to reverse proxy to")
 	healthcheck          = flag.Bool("healthcheck", false, "run a health check against Anubis")
-	debugXRealIPDefault  = flag.String("debug-x-real-ip-default", "", "If set, replace empty X-Real-Ip headers with this value, useful only for debugging Anubis and running it locally")
+	useRemoteAddress     = flag.Bool("use-remote-address", false, "read the client's IP address from the network request, useful for debugging and running Anubis on bare metal")
 )
 
 func keyFromHex(value string) (ed25519.PrivateKey, error) {
@@ -214,7 +214,7 @@ func main() {
 
 	var h http.Handler
 	h = s
-	h = internal.DefaultXRealIP(*debugXRealIPDefault, h)
+	h = internal.RemoteXRealIP(useRemoteAddress, h)
 	h = internal.XForwardedForToXRealIP(h)
 
 	srv := http.Server{Handler: h}
@@ -226,7 +226,7 @@ func main() {
 		"serveRobotsTXT", *robotsTxt,
 		"target", *target,
 		"version", anubis.Version,
-		"debug-x-real-ip-default", *debugXRealIPDefault,
+		"use-remote-address", *useRemoteAddress,
 	)
 
 	go func() {

--- a/cmd/anubis/main.go
+++ b/cmd/anubis/main.go
@@ -214,7 +214,7 @@ func main() {
 
 	var h http.Handler
 	h = s
-	h = internal.RemoteXRealIP(useRemoteAddress, h)
+	h = internal.RemoteXRealIP(*useRemoteAddress, h)
 	h = internal.XForwardedForToXRealIP(h)
 
 	srv := http.Server{Handler: h}

--- a/docs/docs/CHANGELOG.md
+++ b/docs/docs/CHANGELOG.md
@@ -11,6 +11,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+- Changed `--debug-x-real-ip-default` to `--use-remote-address`, getting the IP address from the request's socket address instead.
 - DroneBL lookups have been disabled by default
 
 ## v1.15.0

--- a/docs/docs/admin/installation.mdx
+++ b/docs/docs/admin/installation.mdx
@@ -55,6 +55,7 @@ Anubis uses these environment variables for configuration:
 | `POLICY_FNAME`            | unset                   | The file containing [bot policy configuration](./policies.md). See the bot policy documentation for more details. If unset, the default bot policy configuration is used.                                                                                                                |
 | `SERVE_ROBOTS_TXT`        | `false`                 | If set `true`, Anubis will serve a default `robots.txt` file that disallows all known AI scrapers by name and then additionally disallows every scraper. This is useful if facts and circumstances make it difficult to change the underlying service to serve such a `robots.txt` file. |
 | `TARGET`                  | `http://localhost:3923` | The URL of the service that Anubis should forward valid requests to. Supports Unix domain sockets, set this to a URI like so: `unix:///path/to/socket.sock`.                                                                                                                             |
+| `USE_REMOTE_ADDRESS`      | unset                   | If set to `true`, Anubis will take the client's IP from the network socket. For production deployments, it is expected that a reverse proxy is used in front of Anubis, which pass the IP using headers, instead.                                                                        |
 
 ### Key generation
 

--- a/internal/headers.go
+++ b/internal/headers.go
@@ -3,6 +3,7 @@ package internal
 import (
 	"log/slog"
 	"net/http"
+	"strings"
 
 	"github.com/TecharoHQ/anubis"
 	"github.com/sebest/xff"
@@ -21,16 +22,16 @@ func UnchangingCache(next http.Handler) http.Handler {
 	})
 }
 
-// DefaultXRealIP sets the X-Real-Ip header to the given value if and only if
-// it is not an empty string.
-func DefaultXRealIP(defaultIP string, next http.Handler) http.Handler {
-	if defaultIP == "" {
-		slog.Debug("skipping middleware, defaultIP is empty")
+// RemoteXRealIP sets the X-Real-Ip header to the request's real IP if
+// the setting is enabled by the user.
+func RemoteXRealIP(useRemoteAddress *bool, next http.Handler) http.Handler {
+	if useRemoteAddress == nil || *useRemoteAddress == false {
+		slog.Debug("skipping middleware, useRemoteAddress is empty")
 		return next
 	}
 
 	return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
-		r.Header.Set("X-Real-Ip", defaultIP)
+		r.Header.Set("X-Real-Ip", strings.Split(r.RemoteAddr, ":")[0])
 		next.ServeHTTP(w, r)
 	})
 }

--- a/lib/anubis_test.go
+++ b/lib/anubis_test.go
@@ -47,7 +47,7 @@ func TestCookieSettings(t *testing.T) {
 		CookieName:        t.Name(),
 	})
 
-	ts := httptest.NewServer(internal.DefaultXRealIP("127.0.0.1", srv))
+	ts := httptest.NewServer(internal.RemoteXRealIP(true, "tcp", srv))
 	defer ts.Close()
 
 	cli := &http.Client{


### PR DESCRIPTION
This is just something that I had to first hack to make local testing work but I saw that the flag `debug-x-real-ip-default` existed later. But I still think that using the remote address is better than just using a fixed string that is passed on the command line or env.

This is something you can take or leave, it doesn't matter to me that much.

Checklist:

- [x] Added a description of the changes to the `[Unreleased]` section of docs/docs/CHANGELOG.md
- [x] Tested this at least manually
