### PR TITLE
chore: remove built binary and prevent accidental addition again

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,6 @@
 .env
 *.rpm
+
+# Go binaries and test artifacts
+main
+*.test


### PR DESCRIPTION
Removes `main` from the repo and updates `.gitignore` to help prevent accidents like this again. `.test` comes from go test binaries, which I feel is also worth excluding

Omitted changelog because this doesn't feel like it needs one!

Checklist:

- [ ] Added a description of the changes to the `[Unreleased]` section of docs/docs/CHANGELOG.md
- [x] Tested this at least manually
