### PR TITLE
lib: fix default difficulty

### DIFF
--- a/docs/docs/CHANGELOG.md
+++ b/docs/docs/CHANGELOG.md
@@ -15,6 +15,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Introduced integration tests using Playwright
 - Refactor & Split up Anubis into cmd and lib.go
 - Fixed bot check to only apply if address range matches
+- Fix default difficulty setting that was broken in a refactor
 
 ## v1.14.2
 

--- a/lib/anubis.go
+++ b/lib/anubis.go
@@ -498,8 +498,8 @@ func (s *Server) check(r *http.Request) (CheckResult, *policy.Bot, error) {
 
 	return cr("default/allow", config.RuleAllow), &policy.Bot{
 		Challenge: &config.ChallengeRules{
-			Difficulty: anubis.DefaultDifficulty,
-			ReportAs:   anubis.DefaultDifficulty,
+			Difficulty: s.policy.DefaultDifficulty,
+			ReportAs:   s.policy.DefaultDifficulty,
 			Algorithm:  config.AlgorithmFast,
 		},
 	}, nil

--- a/lib/anubis_test.go
+++ b/lib/anubis_test.go
@@ -1,0 +1,81 @@
+package lib
+
+import (
+	"fmt"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+
+	"github.com/TecharoHQ/anubis"
+)
+
+func spawnAnubis(t *testing.T, h http.Handler) string {
+	t.Helper()
+
+	policy, err := LoadPoliciesOrDefault("", anubis.DefaultDifficulty)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	s, err := New(Options{
+		Next:           h,
+		Policy:         policy,
+		ServeRobotsTXT: true,
+	})
+	if err != nil {
+		t.Fatalf("can't construct libanubis.Server: %v", err)
+	}
+
+	ts := httptest.NewServer(s)
+	t.Log(ts.URL)
+
+	t.Cleanup(func() {
+		ts.Close()
+	})
+
+	return ts.URL
+}
+
+func TestCheckDefaultDifficultyMatchesPolicy(t *testing.T) {
+	h := http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		fmt.Fprintln(w, "OK")
+	})
+
+	for i := 1; i < 10; i++ {
+		t.Run(fmt.Sprint(i), func(t *testing.T) {
+			policy, err := LoadPoliciesOrDefault("", i)
+			if err != nil {
+				t.Fatal(err)
+			}
+
+			s, err := New(Options{
+				Next:           h,
+				Policy:         policy,
+				ServeRobotsTXT: true,
+			})
+			if err != nil {
+				t.Fatalf("can't construct libanubis.Server: %v", err)
+			}
+
+			req, err := http.NewRequest(http.MethodGet, "/", nil)
+			if err != nil {
+				t.Fatal(err)
+			}
+
+			req.Header.Add("X-Real-Ip", "127.0.0.1")
+
+			_, bot, err := s.check(req)
+			if err != nil {
+				t.Fatal(err)
+			}
+
+			if bot.Challenge.Difficulty != i {
+				t.Errorf("Challenge.Difficulty is wrong, wanted %d, got: %d", i, bot.Challenge.Difficulty)
+			}
+
+			if bot.Challenge.ReportAs != i {
+				t.Errorf("Challenge.ReportAs is wrong, wanted %d, got: %d", i, bot.Challenge.ReportAs)
+			}
+		})
+	}
+}


### PR DESCRIPTION
Before this did not respect the difficulty flag and instead used difficulty 4. This has been fixed.

<!-- delete me and describe your change here -->

Checklist:

- [x] Added a description of the changes to the `[Unreleased]` section of docs/docs/CHANGELOG.md
- [x] Tested this at least manually
