### PR TITLE
Linting and staticcheck fixes.

### DIFF
--- a/decaymap/decaymap.go
+++ b/decaymap/decaymap.go
@@ -64,7 +64,7 @@ func (m *Impl[K, V]) Get(key K) (V, bool) {
 		m.lock.Lock()
 		// Since previously reading m.data[key], the value may have been updated.
 		// Delete the entry only if the expiry time is still the same.
-		if m.data[key].expiry == value.expiry {
+		if m.data[key].expiry.Equal(value.expiry) {
 			delete(m.data, key)
 		}
 		m.lock.Unlock()

--- a/docs/docs/CHANGELOG.md
+++ b/docs/docs/CHANGELOG.md
@@ -16,6 +16,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Refactor & Split up Anubis into cmd and lib.go
 - Fixed bot check to only apply if address range matches
 - Fix default difficulty setting that was broken in a refactor
+- Linting fixes and addition of SetNext for changing the next handler in a chain.
 
 ## v1.14.2
 

--- a/docs/docs/CHANGELOG.md
+++ b/docs/docs/CHANGELOG.md
@@ -16,7 +16,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Refactor & Split up Anubis into cmd and lib.go
 - Fixed bot check to only apply if address range matches
 - Fix default difficulty setting that was broken in a refactor
-- Linting fixes and addition of SetNext for changing the next handler in a chain.
+- Linting fixes
 
 ## v1.14.2
 

--- a/internal/test/playwright_test.go
+++ b/internal/test/playwright_test.go
@@ -153,7 +153,7 @@ func startPlaywright(t *testing.T) {
 
 	daemonize(t, fmt.Sprintf("npx --yes playwright@%s run-server --port %d", playwrightVersion, *playwrightPort))
 
-	for true {
+	for {
 		if _, err := http.Get(fmt.Sprintf("http://localhost:%d", *playwrightPort)); err != nil {
 			time.Sleep(500 * time.Millisecond)
 			continue
@@ -355,7 +355,7 @@ func pwTimeout(tc testCase, deadline time.Time) *float64 {
 		max = *playwrightMaxHardTime
 	}
 
-	d := deadline.Sub(time.Now())
+	d := time.Until(deadline)
 	if d <= 0 || d > max {
 		return playwright.Float(float64(max.Milliseconds()))
 	}

--- a/lib/anubis.go
+++ b/lib/anubis.go
@@ -513,7 +513,3 @@ func (s *Server) checkRemoteAddress(b policy.Bot, addr net.IP) bool {
 
 	return ok
 }
-
-func (s *Server) SetNext(next http.Handler) {
-	s.next = next
-}

--- a/lib/anubis.go
+++ b/lib/anubis.go
@@ -98,10 +98,6 @@ func New(opts Options) (*Server, error) {
 		return nil, fmt.Errorf("failed to generate ed25519 key: %w", err)
 	}
 
-	if err != nil {
-		return nil, err // parseConfig sets a fancy error for us
-	}
-
 	result := &Server{
 		next:       opts.Next,
 		priv:       priv,
@@ -516,4 +512,8 @@ func (s *Server) checkRemoteAddress(b policy.Bot, addr net.IP) bool {
 	}
 
 	return ok
+}
+
+func (s *Server) SetNext(next http.Handler) {
+	s.next = next
 }

--- a/lib/policy/config/config.go
+++ b/lib/policy/config/config.go
@@ -51,7 +51,7 @@ func (b BotConfig) Valid() error {
 		errs = append(errs, ErrBotMustHaveName)
 	}
 
-	if b.UserAgentRegex == nil && b.PathRegex == nil && (b.RemoteAddr == nil || len(b.RemoteAddr) == 0) {
+	if b.UserAgentRegex == nil && b.PathRegex == nil && len(b.RemoteAddr) == 0 {
 		errs = append(errs, ErrBotMustHaveUserAgentOrPath)
 	}
 
@@ -71,7 +71,7 @@ func (b BotConfig) Valid() error {
 		}
 	}
 
-	if b.RemoteAddr != nil && len(b.RemoteAddr) > 0 {
+	if len(b.RemoteAddr) > 0 {
 		for _, cidr := range b.RemoteAddr {
 			if _, _, err := net.ParseCIDR(cidr); err != nil {
 				errs = append(errs, ErrInvalidCIDR, err)


### PR DESCRIPTION
I ran golangci-lint and applied some of the errors it reported. 

Some of the changes:

- Removal of nil check on `[]string`, as it is not a pointer, so always has a 0 value of empty.
- Using `Equal()` for time, instead of `==` to insure it is handled properly.
- Use `time.Until()` instead of doing the subtraction manually with time.now()
- Fix error handling while parsing and validation the config. We were setting the error, then moving the for-loop along, losing the error.
- Switched it to use a list, instead of `errors.Join` directly, so that it is more obvious what we are doing and not losing information prematurely.
- Excess noop err check.

Checklist:

- [x] Added a description of the changes to the `[Unreleased]` section of docs/docs/CHANGELOG.md
- [x] Tested this at least manually
