### PR TITLE
data: disable DroneBL lookups by default

### DIFF
--- a/data/botPolicies.json
+++ b/data/botPolicies.json
@@ -394,5 +394,5 @@
       "action": "CHALLENGE"
     }
   ],
-  "dnsbl": true
+  "dnsbl": false
 }

--- a/docs/docs/CHANGELOG.md
+++ b/docs/docs/CHANGELOG.md
@@ -11,6 +11,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+- DroneBL lookups have been disabled by default
+
 ## v1.15.0
 
 Zenos yae Galvus


### PR DESCRIPTION
Closes #109

This was a hack I did on stream. I thought this would have a positive effect, but a combination of real-world testing from people using Anubis in prod and gray-hat testing has proven this is an unfeature and is probably causing more harm than good at this stage.

In the future I'll probably make the `dnsbl` block more flexible so that you can specify your own lists and rules around them.

<!-- delete me and describe your change here -->

Checklist:

- [x] Added a description of the changes to the `[Unreleased]` section of docs/docs/CHANGELOG.md
- [x] Tested this at least manually
