### PR TITLE
docs/developer: add build directions for manually building Anubis

### DIFF
--- a/docs/docs/developer/building-anubis.md
+++ b/docs/docs/developer/building-anubis.md
@@ -1,0 +1,41 @@
+---
+title: Building Anubis without Docker
+---
+
+:::note
+
+These instructions may work, but for right now they are informative for downstream packagers more than they are ready-made instructions for administrators wanting to run Anubis on their servers.
+
+:::end
+
+## Tools needed
+
+In order to build a production-ready binary of Anubis, you need the following packages in your environment:
+
+- [Go](https://go.dev) - the programming language that Anubis is written in
+- [esbuild](https://esbuild.github.io/) - the JavaScript bundler Anubis uses for its production JS assets
+- [Node.JS & NPM](https://nodejs.org/en) - manages some build dependencies
+- `gzip` - compresses production JS (part of coreutils)
+- `zstd` - compresses production JS
+- `brotli` - compresses production JS
+
+## Install dependencies
+
+```text
+go mod download
+npm ci
+```
+
+## Building static assets
+
+```text
+npm run assets
+```
+
+## Building Anubis to the `./var` folder
+
+```text
+go build -o ./var/anubis ./cmd/anubis
+```
+
+From this point it is up to you to make sure that `./var/anubis` ends up in the right place. You may want to consult the `./run` folder for useful files such as a systemd unit and `anubis.env.default` file.

--- a/yeetfile.js
+++ b/yeetfile.js
@@ -1,12 +1,16 @@
-go.install();
-
-["amd64", "arm64"].forEach(goarch => {
+["amd64", "arm64", "riscv64"].forEach(goarch => {
     [deb, rpm].forEach(method => method.build({
         name: "anubis",
         description: "Anubis weighs the souls of incoming HTTP requests and uses a sha256 proof-of-work challenge in order to protect upstream resources from scraper bots.",
         homepage: "https://anubis.techaro.lol",
         license: "MIT",
         goarch,
+
+        documentation: {
+            "./README.md": "README.md",
+            "./LICENSE": "LICENSE",
+            "./docs/docs/CHANGELOG.md": "CHANGELOG.md",
+        },
 
         build: (out) => {
             // install Anubis binary


### PR DESCRIPTION
Provides directions that would have helped #153 be self-serving.
