### PR TITLE
cmd/containerbuild: Use TrimSuffix instead of TrimRight on containerbuild

### DIFF
--- a/cmd/containerbuild/main.go
+++ b/cmd/containerbuild/main.go
@@ -30,7 +30,7 @@ func main() {
 
 	internal.InitSlog(*slogLevel)
 
-	koDockerRepo := strings.TrimRight(*dockerRepo, "/"+filepath.Base(*dockerRepo))
+	koDockerRepo := strings.TrimSuffix(*dockerRepo, "/"+filepath.Base(*dockerRepo))
 
 	if *githubEventName == "pull_request" && *pullRequestID != -1 {
 		*dockerRepo = fmt.Sprintf("ttl.sh/techaro/pr-%d/anubis", *pullRequestID)

--- a/docs/docs/CHANGELOG.md
+++ b/docs/docs/CHANGELOG.md
@@ -20,6 +20,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Developer documentation has been added to the docs site
 - Show more errors when some predictable challenge page errors happen ([#150](https://github.com/TecharoHQ/anubis/issues/150))
 - Verification page now shows hash rate and a progress bar for completion probability.
+- Use `TrimSuffix` instead of `TrimRight` on containerbuild
 
 ## v1.15.0
 


### PR DESCRIPTION
Using TrimRight will remove all characters from `*dockerRepo` from right to left that match a character contained on `"/"+filepath.Base(*dockerRepo)` (the cutset) until it doesn't matches anymore.

So for example, if `dockerRepo` is `example.com/fijxu/anubis`, and `"/"+filepath.Base(*dockerRepo)` is `/anubis`, it will remove `u/anubis` and not just `/anubis` from `dockerRepo` because `u` is a character inside the cutoff.

here is a small example if you want to try it before merging it:

```golang
package main

import "fmt"
import "strings"
import "path/filepath"

func main() {
  dockerRepo := "example.com/fijxu/anubis"
	koDockerRepo := strings.TrimSuffix(dockerRepo, "/"+filepath.Base(dockerRepo))
	koDockerRepoSuffix := strings.TrimRight(dockerRepo, "/"+filepath.Base(dockerRepo))
	fmt.Println(koDockerRepo)
	fmt.Println(koDockerRepoSuffix)
}
```

Silly bug...

Checklist:

- [x] Added a description of the changes to the `[Unreleased]` section of docs/docs/CHANGELOG.md
- [ ] Added test cases to [the relevant parts of the codebase](https://anubis.techaro.lol/docs/developer/code-quality)
- [ ] Ran integration tests `npm run test:integration`
