### PR TITLE
web/js: Add LibreJS banner to Anubis JavaScript to allow LibreJS users to run the challenge

### DIFF
--- a/docs/docs/CHANGELOG.md
+++ b/docs/docs/CHANGELOG.md
@@ -21,6 +21,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Show more errors when some predictable challenge page errors happen ([#150](https://github.com/TecharoHQ/anubis/issues/150))
 - Verification page now shows hash rate and a progress bar for completion probability.
 - Use `TrimSuffix` instead of `TrimRight` on containerbuild
+- Add project license in the JavaScript used by Anubis
 
 ## v1.15.0
 

--- a/docs/docs/CHANGELOG.md
+++ b/docs/docs/CHANGELOG.md
@@ -21,7 +21,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Show more errors when some predictable challenge page errors happen ([#150](https://github.com/TecharoHQ/anubis/issues/150))
 - Verification page now shows hash rate and a progress bar for completion probability.
 - Use `TrimSuffix` instead of `TrimRight` on containerbuild
-- Add project license in the JavaScript used by Anubis
+- Add [LibreJS](https://www.gnu.org/software/librejs/) banner to Anubis JavaScript to allow LibreJS users to run the challenge
 
 ## v1.15.0
 

--- a/web/build.sh
+++ b/web/build.sh
@@ -4,7 +4,35 @@ set -euo pipefail
 
 cd "$(dirname "$0")"
 
-esbuild js/main.mjs --sourcemap --bundle --minify --outfile=static/js/main.mjs
+LICENSE='/*
+@licstart  The following is the entire license notice for the
+JavaScript code in this page.
+
+Copyright (c) 2025 Xe Iaso <me@xeiaso.net>
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in
+all copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+THE SOFTWARE.
+
+@licend  The above is the entire license notice
+for the JavaScript code in this page.
+*/'
+
+esbuild js/main.mjs --sourcemap --bundle --minify --outfile=static/js/main.mjs "--banner:js=${LICENSE}"
 gzip -f -k static/js/main.mjs
 zstd -f -k --ultra -22 static/js/main.mjs
 brotli -fZk static/js/main.mjs


### PR DESCRIPTION
This will allow [LibreJS](https://www.gnu.org/software/librejs/) users to pass the captcha without having to whitelist Anubis manually.

I'm not sure if all the code used is MIT since it was taken from another sources, but is up to you @Xe

If you want me to make any changes, just tell me.

If you want to test it with LibreJS before merging it, you can test it by clicking any video on https://inv.nadeko.net or by pulling https://git.nadeko.net/Fijxu/-/packages/container/anubis/latest (https://git.nadeko.net/Fijxu/anubis-patches/actions/runs/23)

<!--
delete me and describe your change here, give enough context for a maintainer to understand what and why

See https://anubis.techaro.lol/docs/developer/code-quality for more information
-->

Checklist:

- [x] Added a description of the changes to the `[Unreleased]` section of docs/docs/CHANGELOG.md
- [ ] Added test cases to [the relevant parts of the codebase](https://anubis.techaro.lol/docs/developer/code-quality)
- [ ] Ran integration tests `npm run test:integration`
