### PR TITLE
fix(logs): Correctly format listener address 

### DIFF
--- a/cmd/anubis/main.go
+++ b/cmd/anubis/main.go
@@ -16,6 +16,7 @@ import (
 	"os"
 	"os/signal"
 	"strconv"
+	"strings"
 	"sync"
 	"syscall"
 	"time"
@@ -79,7 +80,11 @@ func setupListener(network string, address string) (net.Listener, string) {
 	case "unix":
 		formattedAddress = "unix:" + address
 	case "tcp":
-		formattedAddress = "http://localhost" + address
+		if strings.HasPrefix(address, ":") { // assume it's just a port e.g. :4259
+			formattedAddress = "http://localhost" + address
+		} else {
+			formattedAddress = "http://" + address
+		}
 	default:
 		formattedAddress = fmt.Sprintf(`(%s) %s`, network, address)
 	}
@@ -232,10 +237,10 @@ func main() {
 	h = internal.XForwardedForToXRealIP(h)
 
 	srv := http.Server{Handler: h}
-	listener, url := setupListener(*bindNetwork, *bind)
+	listener, listenerUrl := setupListener(*bindNetwork, *bind)
 	slog.Info(
 		"listening",
-		"url", url,
+		"url", listenerUrl,
 		"difficulty", *challengeDifficulty,
 		"serveRobotsTXT", *robotsTxt,
 		"target", *target,

--- a/docs/docs/CHANGELOG.md
+++ b/docs/docs/CHANGELOG.md
@@ -21,7 +21,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Show more errors when some predictable challenge page errors happen ([#150](https://github.com/TecharoHQ/anubis/issues/150))
 - Verification page now shows hash rate and a progress bar for completion probability.
 - Use `TrimSuffix` instead of `TrimRight` on containerbuild
-
+- Fix the startup logs to correctly show the address and port the server is listening on
 ## v1.15.0
 
 Zenos yae Galvus


### PR DESCRIPTION
closes #93 

Handle addresses that include a hostname, not just ports.  If the address starts with a colon, assume it's just a port and prefix it with "http://localhost".  Otherwise, prefix the entire address with "http://".  This ensures that the listener URL is correctly formatted regardless of whether it includes a hostname or just a port.


Checklist:

- [x] Added a description of the changes to the `[Unreleased]` section of docs/docs/CHANGELOG.md
- [ ] Added test cases to [the relevant parts of the codebase](https://anubis.techaro.lol/docs/developer/code-quality)
- [x] Ran integration tests `npm run test:integration`
