### PR TITLE
xess: fix asset generation with `-mod=vendor`

### DIFF
--- a/xess/xess.go
+++ b/xess/xess.go
@@ -12,7 +12,7 @@ import (
 	"github.com/TecharoHQ/anubis/internal"
 )
 
-//go:generate go run github.com/a-h/templ/cmd/templ@latest generate
+//go:generate go tool github.com/a-h/templ/cmd/templ generate
 
 var (
 	//go:embed *.css static


### PR DESCRIPTION
In `xess`, use `go tool ...` instead of `go run ...@latest` for `go:generate`.

When using the latter, generation of assets with the `-mod=vendor` flag fails. A notable example of this is with Nixpkgs' `buildGoModule`.

```
> @techaro/anubis@1.0.0-see-VERSION-file assets
> go generate ./... && ./web/build.sh && ./xess/build.sh

(✓) Complete [ updates=2 duration=3.625777ms ]
go: github.com/a-h/templ/cmd/templ@latest: cannot query module due to -mod=vendor
xess/xess.go:15: running "go": exit status 1
```

This PR removes `@latest` from the command, and changes `go run` to `go tool` to be consistent with other files.

Checklist:

- [ ] Added a description of the changes to the `[Unreleased]` section of docs/docs/CHANGELOG.md
	- I don't think one is needed since this is a build-time fix and should not impact users.
- [ ] Added test cases to [the relevant parts of the codebase](https://anubis.techaro.lol/docs/developer/code-quality)
- [x] Ran integration tests `npm run test:integration`
