### PR TITLE
Fix: Correct typo in challenge page title (main)

### DIFF
--- a/docs/docs/CHANGELOG.md
+++ b/docs/docs/CHANGELOG.md
@@ -24,7 +24,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Use `TrimSuffix` instead of `TrimRight` on containerbuild
 - Fix the startup logs to correctly show the address and port the server is listening on
 - Add [LibreJS](https://www.gnu.org/software/librejs/) banner to Anubis JavaScript to allow LibreJS users to run the challenge
-
+- Fixed a typo in the challenge page title.
 ## v1.15.0
 
 Zenos yae Galvus

--- a/lib/anubis.go
+++ b/lib/anubis.go
@@ -332,7 +332,7 @@ func (s *Server) MaybeReverseProxy(w http.ResponseWriter, r *http.Request) {
 func (s *Server) RenderIndex(w http.ResponseWriter, r *http.Request) {
 	handler := internal.NoStoreCache(
 		templ.Handler(
-			web.Base("Making sure you\\'re not a bot!", web.Index()),
+			web.Base("Making sure you're not a bot!", web.Index()),
 		),
 	)
 	handler.ServeHTTP(w, r)


### PR DESCRIPTION
- Fixed a typo in the challenge page title, removing an unnecessary backslash.
- Updated the index page title to "Making sure you're not a bot!".

closes #171 

Checklist:

- [x] Added a description of the changes to the `[Unreleased]` section of docs/docs/CHANGELOG.md
- [ ] Added test cases to [the relevant parts of the codebase](https://anubis.techaro.lol/docs/developer/code-quality)
- [x] Ran integration tests `npm run test:integration` (unsupported on Windows, please use WSL)
