### PR TITLE
cmd/anubis: support ED25519_PRIVATE_KEY_HEX_FILE

### DIFF
--- a/docs/docs/CHANGELOG.md
+++ b/docs/docs/CHANGELOG.md
@@ -28,6 +28,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Added a wait with button continue + 30 second auto continue after 30s if you click "Why am I seeing this?"
 - Fixed a typo in the challenge page title.
 - Disabled running integration tests on Windows hosts due to it's reliance on posix features (see [#133](https://github.com/TecharoHQ/anubis/pull/133#issuecomment-2764732309)).
+- Added support for passing the ed25519 signing key in a file with `-ed25519-private-key-hex-file` or `ED25519_PRIVATE_KEY_HEX_FILE`.
 
 ## v1.15.1
 


### PR DESCRIPTION
Closes #182.

There doesn't look currently to be tests that cover `cmd/anubis` itself, so I haven't added a test for this. I have tested manually that it does what we expect.

Checklist:

- [x] Added a description of the changes to the `[Unreleased]` section of docs/docs/CHANGELOG.md
- [x] Added test cases to [the relevant parts of the codebase](https://anubis.techaro.lol/docs/developer/code-quality)
- [x] Ran integration tests `npm run test:integration` (unsupported on Windows, please use WSL)
