### PR TITLE
add a Makefile

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,0 +1,25 @@
+NODE_MODULES = 'node_modules'
+
+.phony: assets build deps lint test
+
+assets:
+	npm run assets
+
+build:
+	ifeq ("$(wildcard $(NODE_MODULES))", "")
+		@echo "please run make deps"
+	else
+		npm run build
+		@echo "Anubis is now built to ./var/anubis"
+	endif
+
+deps:
+	npm ci
+	go mod download
+
+lint:
+	go vet ./...
+	staticcheck ./...
+
+test:
+	npm run test

--- a/Makefile
+++ b/Makefile
@@ -1,21 +1,21 @@
-NODE_MODULES = 'node_modules'
+NODE_MODULES = node_modules
 
-.phony: assets build deps lint test
+.PHONY: build assets deps lint test
 
-assets:
+$(NODE_MODULES):
 	npm run assets
 
-build:
-	ifeq ("$(wildcard $(NODE_MODULES))", "")
-		@echo "please run make deps"
-	else
-		npm run build
-		@echo "Anubis is now built to ./var/anubis"
-	endif
+assets: $(NODE_MODULES)
 
-deps:
+deps: assets
 	npm ci
 	go mod download
+
+build: deps
+	npm run build
+	@echo "Anubis is now built to ./var/anubis"
+
+all: build
 
 lint:
 	go vet ./...

--- a/docs/docs/CHANGELOG.md
+++ b/docs/docs/CHANGELOG.md
@@ -30,6 +30,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Disabled running integration tests on Windows hosts due to it's reliance on posix features (see [#133](https://github.com/TecharoHQ/anubis/pull/133#issuecomment-2764732309)).
 - Added support for passing the ed25519 signing key in a file with `-ed25519-private-key-hex-file` or `ED25519_PRIVATE_KEY_HEX_FILE`.
 - Fixed minor typos
+- Added a Makefile to enable comfortable workflows for downstream packagers.
 
 ## v1.15.1
 

--- a/docs/docs/developer/building-anubis.md
+++ b/docs/docs/developer/building-anubis.md
@@ -22,20 +22,23 @@ In order to build a production-ready binary of Anubis, you need the following pa
 ## Install dependencies
 
 ```text
-go mod download
-npm ci
+make deps
 ```
+
+This will download Go and NPM dependencies.
 
 ## Building static assets
 
 ```text
-npm run assets
+make assets
 ```
+
+This will build all static assets (CSS, JavaScript) for distribution.
 
 ## Building Anubis to the `./var` folder
 
 ```text
-go build -o ./var/anubis ./cmd/anubis
+make build
 ```
 
 From this point it is up to you to make sure that `./var/anubis` ends up in the right place. You may want to consult the `./run` folder for useful files such as a systemd unit and `anubis.env.default` file.

--- a/package.json
+++ b/package.json
@@ -7,6 +7,7 @@
     "test": "npm run assets && go test ./...",
     "test:integration": "npm run assets && go test -v ./internal/test",
     "assets": "go generate ./... && ./web/build.sh && ./xess/build.sh",
+    "build": "npm run assets && go build -o ./var/anubis ../cmd/anubis",
     "dev": "npm run assets && go run ./cmd/anubis --use-remote-address",
     "container": "npm run assets && go run ./cmd/containerbuild"
   },


### PR DESCRIPTION
Based on advice from IRC, a makefile helps downstream packagers understand how to build the software.

Checklist:

- [x] Added a description of the changes to the `[Unreleased]` section of docs/docs/CHANGELOG.md