### PR TITLE
docs/user/known-instances: add page

### DIFF
--- a/docs/docs/user/known-instances.md
+++ b/docs/docs/user/known-instances.md
@@ -1,0 +1,10 @@
+---
+title: List of known websites using Anubis
+---
+
+This page contains a non-exhaustive list with all websites using Anubis.
+
+* https://gitlab.gnome.org/
+* https://git.sr.ht/
+* https://source.puri.sm/
+* https://git.kernel.org/


### PR DESCRIPTION
I've been keeping a list in my head for a while, but I think a canonical location with most known instances could help others, e.g. for deciding wheather to use Anubis or not and to get in contact with Anubis operators.

<!--
delete me and describe your change here, give enough context for a maintainer to understand what and why

See https://anubis.techaro.lol/docs/developer/code-quality for more information
-->

Checklist:

- [ ] Added a description of the changes to the `[Unreleased]` section of docs/docs/CHANGELOG.md
- [ ] Added test cases to [the relevant parts of the codebase](https://anubis.techaro.lol/docs/developer/code-quality)
- [ ] Ran integration tests `npm run test:integration` (unsupported on Windows, please use WSL)
