### PR TITLE
Makefile: fix subtle logic bug

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -2,12 +2,10 @@ NODE_MODULES = node_modules
 
 .PHONY: build assets deps lint test
 
-$(NODE_MODULES):
+assets:
 	npm run assets
 
-assets: $(NODE_MODULES)
-
-deps: assets
+deps:
 	npm ci
 	go mod download
 
@@ -19,7 +17,7 @@ all: build
 
 lint:
 	go vet ./...
-	staticcheck ./...
+	go tool staticcheck ./...
 
 test:
 	npm run test

--- a/docs/docs/developer/building-anubis.md
+++ b/docs/docs/developer/building-anubis.md
@@ -4,7 +4,7 @@ title: Building Anubis without Docker
 
 :::note
 
-These instructions may work, but for right now they are informative for downstream packagers more than they are ready-made instructions for administrators wanting to run Anubis on their servers.
+These instructions may work, but for right now they are informative for downstream packagers more than they are ready-made instructions for administrators wanting to run Anubis on their servers. Pre-made binary package support is being tracked in [#156](https://github.com/TecharoHQ/anubis/issues/156).
 
 :::
 
@@ -12,14 +12,21 @@ These instructions may work, but for right now they are informative for downstre
 
 In order to build a production-ready binary of Anubis, you need the following packages in your environment:
 
-- [Go](https://go.dev) - the programming language that Anubis is written in
+- [Go](https://go.dev) at least version 1.24 - the programming language that Anubis is written in
 - [esbuild](https://esbuild.github.io/) - the JavaScript bundler Anubis uses for its production JS assets
 - [Node.JS & NPM](https://nodejs.org/en) - manages some build dependencies
 - `gzip` - compresses production JS (part of coreutils)
 - `zstd` - compresses production JS
 - `brotli` - compresses production JS
 
-## Install dependencies
+To upgrade your version of Go without system package manager support, install `golang.org/dl/go1.24.2` (this can be done from any version of Go):
+
+```text
+go install golang.org/dl/go1.24.2@latest
+go1.24.2 download
+```
+
+### Install dependencies
 
 ```text
 make deps
@@ -27,7 +34,7 @@ make deps
 
 This will download Go and NPM dependencies.
 
-## Building static assets
+### Building static assets
 
 ```text
 make assets
@@ -35,10 +42,16 @@ make assets
 
 This will build all static assets (CSS, JavaScript) for distribution.
 
-## Building Anubis to the `./var` folder
+### Building Anubis to the `./var` folder
 
 ```text
 make build
 ```
 
 From this point it is up to you to make sure that `./var/anubis` ends up in the right place. You may want to consult the `./run` folder for useful files such as a systemd unit and `anubis.env.default` file.
+
+## Development dependencies
+
+Optionally, you can install the following dependencies for development:
+
+- [Staticcheck](https://staticcheck.dev/docs/getting-started/) (optional, not required due to [`go tool staticcheck`](https://www.alexedwards.net/blog/how-to-manage-tool-dependencies-in-go-1.24-plus), but required if you are using any version of Go older than 1.24)

--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module github.com/TecharoHQ/anubis
 
-go 1.24.1
+go 1.24.2
 
 require (
 	github.com/a-h/templ v0.3.833
@@ -13,6 +13,7 @@ require (
 )
 
 require (
+	github.com/BurntSushi/toml v1.4.1-0.20240526193622-a339e1f7089c // indirect
 	github.com/PuerkitoBio/goquery v1.10.1 // indirect
 	github.com/a-h/parse v0.0.0-20250122154542-74294addb73e // indirect
 	github.com/andybalholm/brotli v1.1.0 // indirect
@@ -39,15 +40,18 @@ require (
 	github.com/prometheus/client_model v0.6.1 // indirect
 	github.com/prometheus/common v0.62.0 // indirect
 	github.com/prometheus/procfs v0.15.1 // indirect
+	golang.org/x/exp/typeparams v0.0.0-20231108232855-2478ac86f678 // indirect
 	golang.org/x/mod v0.24.0 // indirect
 	golang.org/x/net v0.37.0 // indirect
 	golang.org/x/sync v0.12.0 // indirect
 	golang.org/x/sys v0.31.0 // indirect
 	golang.org/x/tools v0.31.0 // indirect
 	google.golang.org/protobuf v1.36.4 // indirect
+	honnef.co/go/tools v0.6.1 // indirect
 )
 
 tool (
 	github.com/a-h/templ/cmd/templ
 	golang.org/x/tools/cmd/stringer
+	honnef.co/go/tools/cmd/staticcheck
 )

--- a/go.sum
+++ b/go.sum
@@ -1,3 +1,5 @@
+github.com/BurntSushi/toml v1.4.1-0.20240526193622-a339e1f7089c h1:pxW6RcqyfI9/kWtOwnv/G+AzdKuy2ZrqINhenH4HyNs=
+github.com/BurntSushi/toml v1.4.1-0.20240526193622-a339e1f7089c/go.mod h1:ukJfTF/6rtPPRCnwkur4qwRxa8vTRFBF0uk2lLoLwho=
 github.com/PuerkitoBio/goquery v1.10.1 h1:Y8JGYUkXWTGRB6Ars3+j3kN0xg1YqqlwvdTV8WTFQcU=
 github.com/PuerkitoBio/goquery v1.10.1/go.mod h1:IYiHrOMps66ag56LEH7QYDDupKXyo5A8qrjIx3ZtujY=
 github.com/a-h/parse v0.0.0-20250122154542-74294addb73e h1:HjVbSQHy+dnlS6C3XajZ69NYAb5jbGNfHanvm1+iYlo=
@@ -86,6 +88,9 @@ golang.org/x/crypto v0.13.0/go.mod h1:y6Z2r+Rw4iayiXXAIxJIDAJ1zMW4yaTpebo8fPOliY
 golang.org/x/crypto v0.19.0/go.mod h1:Iy9bg/ha4yyC70EfRS8jz+B6ybOBKMaSxLj6P6oBDfU=
 golang.org/x/crypto v0.23.0/go.mod h1:CKFgDieR+mRhux2Lsu27y0fO304Db0wZe70UKqHu0v8=
 golang.org/x/crypto v0.31.0/go.mod h1:kDsLvtWBEx7MV9tJOj9bnXsPbxwJQ6csT/x4KIN4Ssk=
+golang.org/x/exp v0.0.0-20231110203233-9a3e6036ecaa h1:FRnLl4eNAQl8hwxVVC17teOw8kdjVDVAiFMtgUdTSRQ=
+golang.org/x/exp/typeparams v0.0.0-20231108232855-2478ac86f678 h1:1P7xPZEwZMoBoz0Yze5Nx2/4pxj6nw9ZqHWXqP0iRgQ=
+golang.org/x/exp/typeparams v0.0.0-20231108232855-2478ac86f678/go.mod h1:AbB0pIl9nAr9wVwH+Z2ZpaocVmF5I4GyWCDIsVjR0bk=
 golang.org/x/mod v0.6.0-dev.0.20220419223038-86c51ed26bb4/go.mod h1:jJ57K6gSWd91VN4djpZkiMVwK6gcyfeH4XE8wZrZaV4=
 golang.org/x/mod v0.8.0/go.mod h1:iBbtSCu2XBx23ZKBPSOrRkjjQPZFPuis4dIYUhu/chs=
 golang.org/x/mod v0.12.0/go.mod h1:iBbtSCu2XBx23ZKBPSOrRkjjQPZFPuis4dIYUhu/chs=
@@ -162,3 +167,5 @@ gopkg.in/yaml.v2 v2.2.2/go.mod h1:hI93XBmqTisBFMUTm0b8Fm+jr3Dg1NNxqwp+5A1VGuI=
 gopkg.in/yaml.v3 v3.0.0-20200313102051-9f266ea9e77c/go.mod h1:K4uyk7z7BCEPqu6E+C64Yfv1cQ7kz7rIZviUmN+EgEM=
 gopkg.in/yaml.v3 v3.0.1 h1:fxVm/GzAzEWqLHuvctI91KS9hhNmmWOoWu0XTYJS7CA=
 gopkg.in/yaml.v3 v3.0.1/go.mod h1:K4uyk7z7BCEPqu6E+C64Yfv1cQ7kz7rIZviUmN+EgEM=
+honnef.co/go/tools v0.6.1 h1:R094WgE8K4JirYjBaOpz/AvTyUu/3wbmAoskKN/pxTI=
+honnef.co/go/tools v0.6.1/go.mod h1:3puzxxljPCe8RGJX7BIy1plGbxEOZni5mR2aXe3/uk4=


### PR DESCRIPTION
Closes #226

Makefile dependencies are backwards, apparently.

Also add staticcheck as a `go tool` dependency and documentation on how to update Go when the system package manager isn't behaving properly.