### PR TITLE
workflows: hash pin more Actions

### DIFF
--- a/.github/workflows/package-builds-stable.yml
+++ b/.github/workflows/package-builds-stable.yml
@@ -13,7 +13,7 @@ jobs:
     #runs-on: alrest-techarohq
     runs-on: ubuntu-latest
     steps:
-    - uses: actions/checkout@v4
+    - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
       with:
         persist-credentials: false
         fetch-tags: true
@@ -28,7 +28,7 @@ jobs:
       uses: Homebrew/actions/setup-homebrew@master
 
     - name: Setup Homebrew cellar cache
-      uses: actions/cache@v4
+      uses: actions/cache@5a3ec84eff668545956fd18022155c47e93e2684 # v4.2.3
       with:
         path: |
           /home/linuxbrew/.linuxbrew/Cellar
@@ -49,7 +49,7 @@ jobs:
         brew bundle
 
     - name: Setup Golang caches
-      uses: actions/cache@v4
+      uses: actions/cache@5a3ec84eff668545956fd18022155c47e93e2684 # v4.2.3
       with:
         path: |
           ~/.cache/go-build

--- a/.github/workflows/package-builds-unstable.yml
+++ b/.github/workflows/package-builds-unstable.yml
@@ -15,7 +15,7 @@ jobs:
     #runs-on: alrest-techarohq
     runs-on: ubuntu-latest
     steps:
-    - uses: actions/checkout@v4
+    - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
       with:
         persist-credentials: false
         fetch-tags: true
@@ -30,7 +30,7 @@ jobs:
       uses: Homebrew/actions/setup-homebrew@master
 
     - name: Setup Homebrew cellar cache
-      uses: actions/cache@v4
+      uses: actions/cache@5a3ec84eff668545956fd18022155c47e93e2684 # v4.2.3
       with:
         path: |
           /home/linuxbrew/.linuxbrew/Cellar
@@ -51,7 +51,7 @@ jobs:
         brew bundle
 
     - name: Setup Golang caches
-      uses: actions/cache@v4
+      uses: actions/cache@5a3ec84eff668545956fd18022155c47e93e2684 # v4.2.3
       with:
         path: |
           ~/.cache/go-build
@@ -70,7 +70,7 @@ jobs:
         sudo apt -y install -f ./var/yeet.deb
         yeet
 
-    - uses: actions/upload-artifact@v4
+    - uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4.6.2
       with:
         name: packages
         path: var/*


### PR DESCRIPTION
Hash pins the workflows added in #194. I don't think this needs another CHANGELOG entry given we already have one for this work.

Checklist:

- [ ] Added a description of the changes to the `[Unreleased]` section of docs/docs/CHANGELOG.md
- [ ] Added test cases to [the relevant parts of the codebase](https://anubis.techaro.lol/docs/developer/code-quality)
- [x] Ran integration tests `npm run test:integration` (unsupported on Windows, please use WSL)
