### PR TITLE
lib/anubis: use the Accept-Language header instead of the User-Agent …

### DIFF
--- a/docs/docs/CHANGELOG.md
+++ b/docs/docs/CHANGELOG.md
@@ -11,6 +11,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+- Updated challenge generation to use the Accept-Encoding header in place of the User-Agent header to allow Chromium browser-switching addons to function.
+
 ## v1.16.0
 
 Fordola rem Lupis

--- a/lib/anubis.go
+++ b/lib/anubis.go
@@ -171,10 +171,10 @@ func (s *Server) challengeFor(r *http.Request, difficulty int) string {
 	fp := sha256.Sum256(s.priv.Seed())
 
 	challengeData := fmt.Sprintf(
-		"Accept-Language=%s,X-Real-IP=%s,User-Agent=%s,WeekTime=%s,Fingerprint=%x,Difficulty=%d",
+		"Accept-Language=%s,Accept-Encoding=%s,X-Real-IP=%s,WeekTime=%s,Fingerprint=%x,Difficulty=%d",
 		r.Header.Get("Accept-Language"),
+		r.Header.Get("Accept-Encoding"),
 		r.Header.Get("X-Real-Ip"),
-		r.UserAgent(),
 		time.Now().UTC().Round(24*7*time.Hour).Format(time.RFC3339),
 		fp,
 		difficulty,
@@ -186,6 +186,7 @@ func (s *Server) MaybeReverseProxy(w http.ResponseWriter, r *http.Request) {
 	lg := slog.With(
 		"user_agent", r.UserAgent(),
 		"accept_language", r.Header.Get("Accept-Language"),
+		"accept_encoding", r.Header.Get("Accept-Encoding"),
 		"priority", r.Header.Get("Priority"),
 		"x-forwarded-for",
 		r.Header.Get("X-Forwarded-For"),
@@ -362,7 +363,7 @@ func (s *Server) RenderBench(w http.ResponseWriter, r *http.Request) {
 }
 
 func (s *Server) MakeChallenge(w http.ResponseWriter, r *http.Request) {
-	lg := slog.With("user_agent", r.UserAgent(), "accept_language", r.Header.Get("Accept-Language"), "priority", r.Header.Get("Priority"), "x-forwarded-for", r.Header.Get("X-Forwarded-For"), "x-real-ip", r.Header.Get("X-Real-Ip"))
+	lg := slog.With("user_agent", r.UserAgent(), "accept_language", r.Header.Get("Accept-Language"), "accept_encoding", r.Header.Get("Accept-Encoding"), "priority", r.Header.Get("Priority"), "x-forwarded-for", r.Header.Get("X-Forwarded-For"), "x-real-ip", r.Header.Get("X-Real-Ip"))
 
 	cr, rule, err := s.check(r)
 	if err != nil {
@@ -393,6 +394,7 @@ func (s *Server) PassChallenge(w http.ResponseWriter, r *http.Request) {
 	lg := slog.With(
 		"user_agent", r.UserAgent(),
 		"accept_language", r.Header.Get("Accept-Language"),
+		"accept_encoding", r.Header.Get("Accept-Encoding"),
 		"priority", r.Header.Get("Priority"),
 		"x-forwarded-for", r.Header.Get("X-Forwarded-For"),
 		"x-real-ip", r.Header.Get("X-Real-Ip"),


### PR DESCRIPTION
…header in challenge generation.

js requests made through the `fetch` call cannot use an altered user agent on chrome. switching to another header means that there is no mismatch between challenge generation and submission comparison.

fixes #239.

Checklist:

- [x] Added a description of the changes to the `[Unreleased]` section of docs/docs/CHANGELOG.md
- [ ] Added test cases to [the relevant parts of the codebase](https://anubis.techaro.lol/docs/developer/code-quality)
- [ ] Ran integration tests `npm run test:integration` (unsupported on Windows, please use WSL)

items 2 and 3 don't apply to this pr. existing test cases cover the behaviour.