### PR TITLE
fix(fetch): improve error handling for Content-Type parsing

### DIFF
--- a/docs/docs/CHANGELOG.md
+++ b/docs/docs/CHANGELOG.md
@@ -13,6 +13,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 - Whitelisted [DuckDuckBot](https://duckduckgo.com/duckduckgo-help-pages/results/duckduckbot/) in botPolicies
 - Improvements to build scripts to make them less independent of the build host
+- Improved the OpenGraph error logging
 
 ## v1.16.0
 

--- a/internal/ogtags/cache.go
+++ b/internal/ogtags/cache.go
@@ -23,7 +23,7 @@ func (c *OGTagCache) GetOGTags(url *url.URL) (map[string]string, error) {
 	if errors.Is(err, syscall.ECONNREFUSED) {
 		slog.Debug("Connection refused, returning empty tags")
 		return nil, nil
-	} else if errors.Is(err, OgHandledError) {
+	} else if errors.Is(err, ErrOgHandled) {
 		// Error was handled in fetchHTMLDocument, return empty tags
 		return nil, nil
 	}

--- a/internal/ogtags/cache.go
+++ b/internal/ogtags/cache.go
@@ -23,8 +23,8 @@ func (c *OGTagCache) GetOGTags(url *url.URL) (map[string]string, error) {
 	if errors.Is(err, syscall.ECONNREFUSED) {
 		slog.Debug("Connection refused, returning empty tags")
 		return nil, nil
-	} else if errors.Is(err, ErrNotFound) {
-		// not even worth a debug log...
+	} else if errors.Is(err, OgHandledError) {
+		// Error was handled in fetchHTMLDocument, return empty tags
 		return nil, nil
 	}
 	if err != nil {

--- a/internal/ogtags/fetch.go
+++ b/internal/ogtags/fetch.go
@@ -11,8 +11,8 @@ import (
 )
 
 var (
-	ErrNotFound = errors.New("page not found") /*todo: refactor into common errors lib? */
-	emptyMap    = map[string]string{}          // used to indicate an empty result in the cache. Can't use nil as it would be a cache miss.
+	OgHandledError = errors.New("og: handled error") // used to indicate that the error was handled and should not be logged
+	emptyMap       = map[string]string{}             // used to indicate an empty result in the cache. Can't use nil as it would be a cache miss.
 )
 
 func (c *OGTagCache) fetchHTMLDocument(urlStr string) (*html.Node, error) {
@@ -31,7 +31,7 @@ func (c *OGTagCache) fetchHTMLDocument(urlStr string) (*html.Node, error) {
 	if resp.StatusCode != http.StatusOK {
 		slog.Debug("og: received non-OK status code", "url", urlStr, "status", resp.StatusCode)
 		c.cache.Set(urlStr, emptyMap, c.ogTimeToLive) // Cache empty result for non-successful status codes
-		return nil, ErrNotFound
+		return nil, fmt.Errorf("%w: page not found", OgHandledError)
 	}
 
 	// Check content type
@@ -43,11 +43,13 @@ func (c *OGTagCache) fetchHTMLDocument(urlStr string) (*html.Node, error) {
 		mediaType, _, err := mime.ParseMediaType(ct)
 		if err != nil {
 			// Malformed Content-Type header
-			return nil, fmt.Errorf("invalid Content-Type '%s': %w", ct, err)
+			slog.Debug("og: malformed Content-Type header", "url", urlStr, "contentType", ct)
+			return nil, fmt.Errorf("%w malformed Content-Type header: %w", OgHandledError, err)
 		}
 
 		if mediaType != "text/html" && mediaType != "application/xhtml+xml" {
-			return nil, fmt.Errorf("unsupported Content-Type: %s", mediaType)
+			slog.Debug("og: unsupported Content-Type", "url", urlStr, "contentType", mediaType)
+			return nil, fmt.Errorf("%w unsupported Content-Type: %s", OgHandledError, mediaType)
 		}
 	}
 

--- a/internal/ogtags/fetch.go
+++ b/internal/ogtags/fetch.go
@@ -11,8 +11,8 @@ import (
 )
 
 var (
-	OgHandledError = errors.New("og: handled error") // used to indicate that the error was handled and should not be logged
-	emptyMap       = map[string]string{}             // used to indicate an empty result in the cache. Can't use nil as it would be a cache miss.
+	ErrOgHandled = errors.New("og: handled error") // used to indicate that the error was handled and should not be logged
+	emptyMap     = map[string]string{}             // used to indicate an empty result in the cache. Can't use nil as it would be a cache miss.
 )
 
 func (c *OGTagCache) fetchHTMLDocument(urlStr string) (*html.Node, error) {
@@ -31,7 +31,7 @@ func (c *OGTagCache) fetchHTMLDocument(urlStr string) (*html.Node, error) {
 	if resp.StatusCode != http.StatusOK {
 		slog.Debug("og: received non-OK status code", "url", urlStr, "status", resp.StatusCode)
 		c.cache.Set(urlStr, emptyMap, c.ogTimeToLive) // Cache empty result for non-successful status codes
-		return nil, fmt.Errorf("%w: page not found", OgHandledError)
+		return nil, fmt.Errorf("%w: page not found", ErrOgHandled)
 	}
 
 	// Check content type
@@ -44,12 +44,12 @@ func (c *OGTagCache) fetchHTMLDocument(urlStr string) (*html.Node, error) {
 		if err != nil {
 			// Malformed Content-Type header
 			slog.Debug("og: malformed Content-Type header", "url", urlStr, "contentType", ct)
-			return nil, fmt.Errorf("%w malformed Content-Type header: %w", OgHandledError, err)
+			return nil, fmt.Errorf("%w malformed Content-Type header: %w", ErrOgHandled, err)
 		}
 
 		if mediaType != "text/html" && mediaType != "application/xhtml+xml" {
 			slog.Debug("og: unsupported Content-Type", "url", urlStr, "contentType", mediaType)
-			return nil, fmt.Errorf("%w unsupported Content-Type: %s", OgHandledError, mediaType)
+			return nil, fmt.Errorf("%w unsupported Content-Type: %s", ErrOgHandled, mediaType)
 		}
 	}
 

--- a/internal/test/playwright_test.go
+++ b/internal/test/playwright_test.go
@@ -101,6 +101,9 @@ func doesNPXExist(t *testing.T) {
 }
 
 func run(t *testing.T, command string) string {
+	if testing.Short() {
+		t.Skip("skipping integration smoke testing in short mode")
+	}
 	t.Helper()
 
 	shPath, err := exec.LookPath("sh")

--- a/lib/anubis_test.go
+++ b/lib/anubis_test.go
@@ -15,12 +15,12 @@ import (
 func loadPolicies(t *testing.T, fname string) *policy.ParsedConfig {
 	t.Helper()
 
-	policy, err := LoadPoliciesOrDefault("", anubis.DefaultDifficulty)
+	anubisPolicy, err := LoadPoliciesOrDefault("", anubis.DefaultDifficulty)
 	if err != nil {
 		t.Fatal(err)
 	}
 
-	return policy
+	return anubisPolicy
 }
 
 func spawnAnubis(t *testing.T, opts Options) *Server {


### PR DESCRIPTION
In the past, you could get logs like ```
{"time":"2025-04-11T18:53:02.39479254Z","level":"ERROR","source":{"function":"github.com/TecharoHQ/anubis/lib.(*Server).RenderIndex","file":"github.com/TecharoHQ/anubis/lib/anubis.go","line":346},"msg":"failed to get OG tags","err":"unsupported Content-Type: image/png"}
``` 
Miss-leading a user that there is an actual error when it's just debug worthy. This PR fixes that along with some other minute changes

also see https://ptb.discord.com/channels/1191183827591241828/1330297062587371602/1360334215748649131 

Checklist:
- [x] Added a description of the changes to the `[Unreleased]` section of docs/docs/CHANGELOG.md
- [x] Added test cases to [the relevant parts of the codebase](https://anubis.techaro.lol/docs/developer/code-quality)
- [ ] Ran integration tests `npm run test:integration` (unsupported on Windows, please use WSL)
