### PR TITLE
cmd/containerbuild/main.go: fix docker tag parsing

### DIFF
--- a/cmd/containerbuild/main.go
+++ b/cmd/containerbuild/main.go
@@ -123,10 +123,10 @@ func parseImageList(imageList string) ([]image, error) {
 		// reg.xeiaso.net/techaro/anubis:latest
 		// repository: reg.xeiaso.net/techaro/anubis
 		// tag:        latest
-		parts := strings.SplitN(img, ":", 2)
+		index := strings.LastIndex(img, ":")
 		result = append(result, image{
-			repository: parts[0],
-			tag:        parts[1],
+			repository: img[:index],
+			tag:        img[index+1:],
 		})
 	}
 


### PR DESCRIPTION
Minor fix to the docker parsing of tags in the image reference to split at the last colon as per the docker spec[1]. This fixes container builds when the repository already contains an earlier colon, which is common when pushing to a local registry with a port, eg: `localhost:5000/org/name:latest`. The previous would be parsed with the repo as `localhost` and tag as `5000/org/name:latest`, which would cause the build to fail.

[1] https://docs.docker.com/reference/cli/docker/image/tag/#description

Checklist:

- [ ] Added a description of the changes to the `[Unreleased]` section of docs/docs/CHANGELOG.md
- [ ] Added test cases to [the relevant parts of the codebase](https://anubis.techaro.lol/docs/developer/code-quality)
- [ ] Ran integration tests `npm run test:integration` (unsupported on Windows, please use WSL)
