### PR TITLE
Create Anubis FreeBSD rc.d script

### DIFF
--- a/docs/docs/CHANGELOG.md
+++ b/docs/docs/CHANGELOG.md
@@ -14,6 +14,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Whitelisted [DuckDuckBot](https://duckduckgo.com/duckduckgo-help-pages/results/duckduckbot/) in botPolicies
 - Improvements to build scripts to make them less independent of the build host
 - Improved the OpenGraph error logging
+- Added FreeBSD rc.d script so can be run as a FreeBSD daemon.
 
 ## v1.16.0
 

--- a/run/anubis.freebsd
+++ b/run/anubis.freebsd
@@ -1,0 +1,34 @@
+#!/bin/sh
+
+# PROVIDE: anubis
+# REQUIRE: NETWORKING
+# KEYWORD: shutdown
+
+. /etc/rc.subr
+
+name=anubis
+rcvar=anubis_enable
+
+load_rc_config ${name}
+
+: ${anubis_enable="NO"}
+: ${anubis_user="anubis"}
+: ${anubis_bin="/usr/local/bin/anubis"}
+: ${anubis_environment_file="/etc/anubis.env"}
+
+command=/usr/sbin/daemon
+procname=${anubis_bin}
+pidfile=/var/run/anubis.pid
+logfile=/var/log/anubis.log
+command_args="-c -f -p ${pidfile} -o ${logfile} ${procname}"
+start_precmd=anubis_precmd
+
+anubis_precmd () {
+        export $(xargs < ${anubis_environment_file})
+        if [ ! -f ${logfile} ]; then
+                install -o anubis /dev/null ${logfile}
+        fi
+        install -o anubis /dev/null ${pidfile}
+}
+
+run_rc_command "$1"


### PR DESCRIPTION
I have added an rc.d script for FreeBSD so Anubis can be run as a daemon.
Typically, this file would be copied to `/usr/local/etc/rc.d` and variables set in `/etc/rc.conf` (i.e. to enable it, and set the environment file).
Tested and running well on my Forgejo Instance - https://forge.notnull.space/

Checklist: 

- [x] Added a description of the changes to the `[Unreleased]` section of docs/docs/CHANGELOG.md
- [ ] Added test cases to [the relevant parts of the codebase](https://anubis.techaro.lol/docs/developer/code-quality)
- [ ] Ran integration tests `npm run test:integration` (unsupported on Windows, please use WSL)
