### PR TITLE
chore(ci): migrate to TecharoHQ/yeet

### DIFF
--- a/.github/workflows/package-builds-stable.yml
+++ b/.github/workflows/package-builds-stable.yml
@@ -64,8 +64,9 @@ jobs:
 
     - name: Build Packages
       run: |
-        wget https://github.com/Xe/x/releases/download/v1.13.4/yeet_1.13.4_amd64.deb -O var/yeet.deb
+        wget https://github.com/TecharoHQ/yeet/releases/download/v0.1.1/yeet_0.1.1_amd64.deb -O var/yeet.deb
         sudo apt -y install -f ./var/yeet.deb
+        rm ./var/yeet.deb
         yeet
 
     - name: Upload released artifacts

--- a/.github/workflows/package-builds-unstable.yml
+++ b/.github/workflows/package-builds-unstable.yml
@@ -66,8 +66,9 @@ jobs:
 
     - name: Build Packages
       run: |
-        wget https://github.com/Xe/x/releases/download/v1.13.4/yeet_1.13.4_amd64.deb -O var/yeet.deb
+        wget https://github.com/TecharoHQ/yeet/releases/download/v0.1.1/yeet_0.1.1_amd64.deb -O var/yeet.deb
         sudo apt -y install -f ./var/yeet.deb
+        rm ./var/yeet.deb
         yeet
 
     - uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4.6.2


### PR DESCRIPTION
Moves to [TecharoHQ/yeet](https://github.com/TecharoHQ/yeet) for the next release.
