### PR TITLE
docs(known-instances): add NixOS Hydra

### DIFF
--- a/docs/docs/user/known-instances.md
+++ b/docs/docs/user/known-instances.md
@@ -28,6 +28,7 @@ This page contains a non-exhaustive list with all websites using Anubis.
 - http://code.hackerspace.pl/
 - https://wiki.archlinux.org/
 - https://git.devuan.org/
+- https://hydra.nixos.org/
 
 - <details>
   <summary>The United Nations</summary>


### PR DESCRIPTION
Updates the known instances list and add the [NixOS Hydra](https://hydra.nixos.org).