### PR TITLE
fix(lib): make Anubis less paranoid

### DIFF
--- a/docs/docs/CHANGELOG.md
+++ b/docs/docs/CHANGELOG.md
@@ -37,6 +37,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Set or append to `X-Forwarded-For` header unless the remote connects over a loopback address [#328](https://github.com/TecharoHQ/anubis/issues/328)
 - Fixed mojeekbot user agent regex
 - Added support for running anubis behind a base path (e.g. `/myapp`)
+- Reduce Anubis' paranoia with user cookies ([#365](https://github.com/TecharoHQ/anubis/pull/365))
 
 ## v1.16.0
 

--- a/docs/docs/admin/policies.mdx
+++ b/docs/docs/admin/policies.mdx
@@ -241,6 +241,6 @@ In case your service needs it for risk calculation reasons, Anubis exposes infor
 | :---------------- | :--------------------------------------------------- | :--------------- |
 | `X-Anubis-Rule`   | The name of the rule that was matched                | `bot/lightpanda` |
 | `X-Anubis-Action` | The action that Anubis took in response to that rule | `CHALLENGE`      |
-| `X-Anubis-Status` | The status and how strict Anubis was in its checks   | `PASS-FULL`      |
+| `X-Anubis-Status` | The status and how strict Anubis was in its checks   | `PASS`           |
 
 Policy rules are matched using [Go's standard library regular expressions package](https://pkg.go.dev/regexp). You can mess around with the syntax at [regex101.com](https://regex101.com), make sure to select the Golang option.

--- a/lib/random.go
+++ b/lib/random.go
@@ -1,9 +1,0 @@
-package lib
-
-import (
-	"math/rand"
-)
-
-func randomJitter() bool {
-	return rand.Intn(100) > 10
-}


### PR DESCRIPTION
Previously Anubis would aggressively make sure that the client cookie matched exactly what it should. This has turned out to be too paranoid in practice and has caused problems with Happy Eyeballs et. al.

This is a potential fix to #303 and #289.

<!--
delete me and describe your change here, give enough context for a maintainer to understand what and why

See https://anubis.techaro.lol/docs/developer/code-quality for more information
-->

Checklist:

- [x] Added a description of the changes to the `[Unreleased]` section of docs/docs/CHANGELOG.md
- [ ] Added test cases to [the relevant parts of the codebase](https://anubis.techaro.lol/docs/developer/code-quality)
- [x] Ran integration tests `npm run test:integration` (unsupported on Windows, please use WSL)
