### PR TITLE
feat(og): Support unix sockets

### DIFF
--- a/docs/docs/CHANGELOG.md
+++ b/docs/docs/CHANGELOG.md
@@ -38,6 +38,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Fixed mojeekbot user agent regex
 - Added support for running anubis behind a base path (e.g. `/myapp`)
 - Reduce Anubis' paranoia with user cookies ([#365](https://github.com/TecharoHQ/anubis/pull/365))
+- Added support for Opengraph passthrough while using unix sockets
 
 ## v1.16.0
 

--- a/internal/ogtags/ogtags.go
+++ b/internal/ogtags/ogtags.go
@@ -1,8 +1,12 @@
 package ogtags
 
 import (
+	"context"
+	"log/slog"
+	"net"
 	"net/http"
 	"net/url"
+	"strings"
 	"time"
 
 	"github.com/TecharoHQ/anubis/decaymap"
@@ -10,7 +14,7 @@ import (
 
 type OGTagCache struct {
 	cache            *decaymap.Impl[string, map[string]string]
-	target           string
+	targetURL        *url.URL
 	ogPassthrough    bool
 	ogTimeToLive     time.Duration
 	approvedTags     []string
@@ -24,15 +28,47 @@ func NewOGTagCache(target string, ogPassthrough bool, ogTimeToLive time.Duration
 	// In the future, these could come from configuration
 	defaultApprovedTags := []string{"description", "keywords", "author"}
 	defaultApprovedPrefixes := []string{"og:", "twitter:", "fediverse:"}
-	client := &http.Client{
-		Timeout: 5 * time.Second, /*make this configurable?*/
+
+	var parsedTargetURL *url.URL
+	var err error
+
+	if target == "" {
+		// Default to localhost if target is empty
+		parsedTargetURL, _ = url.Parse("http://localhost")
+	} else {
+		parsedTargetURL, err = url.Parse(target)
+		if err != nil {
+			slog.Debug("og: failed to parse target URL, treating as non-unix", "target", target, "error", err)
+			// If parsing fails, treat it as a non-unix target for backward compatibility or default behavior
+			// For now, assume it's not a scheme issue but maybe an invalid char, etc.
+			// A simple string target might be intended if it's not a full URL.
+			parsedTargetURL = &url.URL{Scheme: "http", Host: target} // Assume http if scheme missing and host-like
+			if !strings.Contains(target, "://") && !strings.HasPrefix(target, "unix:") {
+				// If it looks like just a host/host:port (and not unix), prepend http:// (todo: is this bad...? Trace path to see if i can yell at user to do it right)
+				parsedTargetURL, _ = url.Parse("http://" + target)
+			}
+		}
 	}
 
-	const maxContentLength = 16 << 20 // 16 MiB in bytes
+	client := &http.Client{
+		Timeout: 5 * time.Second, /*todo: make this configurable?*/
+	}
+
+	// Configure custom transport for Unix sockets
+	if parsedTargetURL.Scheme == "unix" {
+		socketPath := parsedTargetURL.Path // For unix scheme, path is the socket path
+		client.Transport = &http.Transport{
+			DialContext: func(_ context.Context, _, _ string) (net.Conn, error) {
+				return net.Dial("unix", socketPath)
+			},
+		}
+	}
+
+	const maxContentLength = 16 << 20 // 16 MiB in bytes, if there is a reasonable reason that you need more than this...Why?
 
 	return &OGTagCache{
 		cache:            decaymap.New[string, map[string]string](),
-		target:           target,
+		targetURL:        parsedTargetURL, // Store the parsed URL
 		ogPassthrough:    ogPassthrough,
 		ogTimeToLive:     ogTimeToLive,
 		approvedTags:     defaultApprovedTags,
@@ -42,8 +78,27 @@ func NewOGTagCache(target string, ogPassthrough bool, ogTimeToLive time.Duration
 	}
 }
 
+// getTarget constructs the target URL string for fetching OG tags.
+// For Unix sockets, it creates a "fake" HTTP URL that the custom dialer understands.
 func (c *OGTagCache) getTarget(u *url.URL) string {
-	return c.target + u.Path
+	if c.targetURL.Scheme == "unix" {
+		// The custom dialer ignores the host, but we need a valid http URL structure.
+		// Use "unix" as a placeholder host. Path and Query from original request are appended.
+		fakeURL := &url.URL{
+			Scheme:   "http", // Scheme must be http/https for client.Get
+			Host:     "unix", // Arbitrary host, ignored by custom dialer
+			Path:     u.Path,
+			RawQuery: u.RawQuery,
+		}
+		return fakeURL.String()
+	}
+
+	// For regular http/https targets
+	target := *c.targetURL // Make a copy
+	target.Path = u.Path
+	target.RawQuery = u.RawQuery
+	return target.String()
+
 }
 
 func (c *OGTagCache) Cleanup() {

--- a/internal/ogtags/ogtags_test.go
+++ b/internal/ogtags/ogtags_test.go
@@ -1,7 +1,16 @@
 package ogtags
 
 import (
+	"context"
+	"errors"
+	"fmt"
+	"net"
+	"net/http"
 	"net/url"
+	"os"
+	"path/filepath"
+	"reflect"
+	"strings"
 	"testing"
 	"time"
 )
@@ -35,8 +44,17 @@ func TestNewOGTagCache(t *testing.T) {
 				t.Fatal("expected non-nil cache, got nil")
 			}
 
-			if cache.target != tt.target {
-				t.Errorf("expected target %s, got %s", tt.target, cache.target)
+			// Check the parsed targetURL, handling the default case for empty target
+			expectedURLStr := tt.target
+			if tt.target == "" {
+				// Default behavior when target is empty is now http://localhost
+				expectedURLStr = "http://localhost"
+			} else if !strings.Contains(tt.target, "://") && !strings.HasPrefix(tt.target, "unix:") {
+				// Handle case where target is just host or host:port (and not unix)
+				expectedURLStr = "http://" + tt.target
+			}
+			if cache.targetURL.String() != expectedURLStr {
+				t.Errorf("expected targetURL %s, got %s", expectedURLStr, cache.targetURL.String())
 			}
 
 			if cache.ogPassthrough != tt.ogPassthrough {
@@ -47,6 +65,45 @@ func TestNewOGTagCache(t *testing.T) {
 				t.Errorf("expected ogTimeToLive %v, got %v", tt.ogTimeToLive, cache.ogTimeToLive)
 			}
 		})
+	}
+}
+
+// TestNewOGTagCache_UnixSocket specifically tests unix socket initialization
+func TestNewOGTagCache_UnixSocket(t *testing.T) {
+	tempDir := t.TempDir()
+	socketPath := filepath.Join(tempDir, "test.sock")
+	target := "unix://" + socketPath
+
+	cache := NewOGTagCache(target, true, 5*time.Minute)
+
+	if cache == nil {
+		t.Fatal("expected non-nil cache, got nil")
+	}
+
+	if cache.targetURL.Scheme != "unix" {
+		t.Errorf("expected targetURL scheme 'unix', got '%s'", cache.targetURL.Scheme)
+	}
+	if cache.targetURL.Path != socketPath {
+		t.Errorf("expected targetURL path '%s', got '%s'", socketPath, cache.targetURL.Path)
+	}
+
+	// Check if the client transport is configured for Unix sockets
+	transport, ok := cache.client.Transport.(*http.Transport)
+	if !ok {
+		t.Fatalf("expected client transport to be *http.Transport, got %T", cache.client.Transport)
+	}
+	if transport.DialContext == nil {
+		t.Fatal("expected client transport DialContext to be non-nil for unix socket")
+	}
+
+	// Attempt a dummy dial to see if it uses the correct path (optional, more involved check)
+	dummyConn, err := transport.DialContext(context.Background(), "", "")
+	if err == nil {
+		dummyConn.Close()
+		t.Log("DialContext seems functional, but couldn't verify path without a listener")
+	} else if !strings.Contains(err.Error(), "connect: connection refused") && !strings.Contains(err.Error(), "connect: no such file or directory") {
+		// We expect connection refused or not found if nothing is listening
+		t.Errorf("DialContext failed with unexpected error: %v", err)
 	}
 }
 
@@ -66,18 +123,33 @@ func TestGetTarget(t *testing.T) {
 			expected: "http://example.com",
 		},
 		{
-			name:     "With complex path",
-			target:   "http://example.com",
-			path:     "/pag(#*((#@)ΓΓΓΓe/Γ",
-			query:    "id=123",
-			expected: "http://example.com/pag(#*((#@)ΓΓΓΓe/Γ",
+			name:   "With complex path",
+			target: "http://example.com",
+			path:   "/pag(#*((#@)ΓΓΓΓe/Γ",
+			query:  "id=123",
+			// Expect URL encoding and query parameter
+			expected: "http://example.com/pag%28%23%2A%28%28%23@%29%CE%93%CE%93%CE%93%CE%93e/%CE%93?id=123",
 		},
 		{
 			name:     "With query and path",
 			target:   "http://example.com",
 			path:     "/page",
 			query:    "id=123",
-			expected: "http://example.com/page",
+			expected: "http://example.com/page?id=123",
+		},
+		{
+			name:     "Unix socket target",
+			target:   "unix:/tmp/anubis.sock",
+			path:     "/some/path",
+			query:    "key=value&flag=true",
+			expected: "http://unix/some/path?key=value&flag=true", // Scheme becomes http, host is 'unix'
+		},
+		{
+			name:     "Unix socket target with ///",
+			target:   "unix:///var/run/anubis.sock",
+			path:     "/",
+			query:    "",
+			expected: "http://unix/",
 		},
 	}
 
@@ -96,5 +168,86 @@ func TestGetTarget(t *testing.T) {
 				t.Errorf("expected %s, got %s", tt.expected, result)
 			}
 		})
+	}
+}
+
+// TestIntegrationGetOGTags_UnixSocket tests fetching OG tags via a Unix socket.
+func TestIntegrationGetOGTags_UnixSocket(t *testing.T) {
+	tempDir := t.TempDir()
+
+	socketPath := filepath.Join(tempDir, "anubis-test.sock")
+
+	// Ensure the socket does not exist initially
+	_ = os.Remove(socketPath)
+
+	// Create a simple HTTP server listening on the Unix socket
+	listener, err := net.Listen("unix", socketPath)
+	if err != nil {
+		t.Fatalf("Failed to listen on unix socket %s: %v", socketPath, err)
+	}
+	defer func(listener net.Listener, socketPath string) {
+		if listener != nil {
+			if err := listener.Close(); err != nil && !errors.Is(err, net.ErrClosed) {
+				t.Logf("Error closing listener: %v", err)
+			}
+		}
+
+		if _, err := os.Stat(socketPath); err == nil {
+			if err := os.Remove(socketPath); err != nil {
+				t.Logf("Error removing socket file %s: %v", socketPath, err)
+			}
+		}
+	}(listener, socketPath)
+
+	server := &http.Server{
+		Handler: http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+			w.Header().Set("Content-Type", "text/html")
+			fmt.Fprintln(w, `<!DOCTYPE html><html><head><meta property="og:title" content="Unix Socket Test" /></head><body>Test</body></html>`)
+		}),
+	}
+	go func() {
+		if err := server.Serve(listener); err != nil && !errors.Is(err, http.ErrServerClosed) {
+			t.Logf("Unix socket server error: %v", err)
+		}
+	}()
+	defer func(server *http.Server, ctx context.Context) {
+		err := server.Shutdown(ctx)
+		if err != nil {
+			t.Logf("Error shutting down server: %v", err)
+		}
+	}(server, context.Background()) // Ensure server is shut down
+
+	// Wait a moment for the server to start
+	time.Sleep(100 * time.Millisecond)
+
+	// Create cache instance pointing to the Unix socket
+	targetURL := "unix://" + socketPath
+	cache := NewOGTagCache(targetURL, true, 1*time.Minute)
+
+	// Create a dummy URL for the request (path and query matter)
+	testReqURL, _ := url.Parse("/some/page?query=1")
+
+	// Get OG tags
+	ogTags, err := cache.GetOGTags(testReqURL)
+
+	if err != nil {
+		t.Fatalf("GetOGTags failed for unix socket: %v", err)
+	}
+
+	expectedTags := map[string]string{
+		"og:title": "Unix Socket Test",
+	}
+
+	if !reflect.DeepEqual(ogTags, expectedTags) {
+		t.Errorf("Expected OG tags %v, got %v", expectedTags, ogTags)
+	}
+
+	// Test cache retrieval (should hit cache)
+	cachedTags, err := cache.GetOGTags(testReqURL)
+	if err != nil {
+		t.Fatalf("GetOGTags (cache hit) failed for unix socket: %v", err)
+	}
+	if !reflect.DeepEqual(cachedTags, expectedTags) {
+		t.Errorf("Expected cached OG tags %v, got %v", expectedTags, cachedTags)
 	}
 }


### PR DESCRIPTION
Closes #329 #319 

Adds support for using the opengraph subsystem while using unix sockets as your TARGET

Checklist:

- [x] Added a description of the changes to the `[Unreleased]` section of docs/docs/CHANGELOG.md
- [x] Added test cases to [the relevant parts of the codebase](https://anubis.techaro.lol/docs/developer/code-quality)
- [ ] Ran integration tests `npm run test:integration` (unsupported on Windows, please use WSL)
