### PR TITLE
docs(known-instances): add Codeberg

### DIFF
--- a/docs/docs/user/known-instances.md
+++ b/docs/docs/user/known-instances.md
@@ -29,9 +29,9 @@ This page contains a non-exhaustive list with all websites using Anubis.
 - https://wiki.archlinux.org/
 - https://git.devuan.org/
 - https://hydra.nixos.org/
-
+- https://hydra.nixos.org/
+- https://codeberg.org/
 - <details>
   <summary>The United Nations</summary>
-
   - https://policytoolbox.iiep.unesco.org/
   </details>


### PR DESCRIPTION
Just checking bypass-all-shortlinks-debloated and they appeared.
