### PR TITLE
fix(cmd/anubis): print "Rule error IDs" in JSON

### DIFF
--- a/cmd/anubis/main.go
+++ b/cmd/anubis/main.go
@@ -207,16 +207,15 @@ func main() {
 		log.Fatalf("can't parse policy file: %v", err)
 	}
 
-	fmt.Println("Rule error IDs:")
+	ruleErrorIDs := make(map[string]string)
 	for _, rule := range policy.Bots {
 		if rule.Action != config.RuleDeny {
 			continue
 		}
 
 		hash := rule.Hash()
-		fmt.Printf("* %s: %s\n", rule.Name, hash)
+		ruleErrorIDs[rule.Name] = hash
 	}
-	fmt.Println()
 
 	// replace the bot policy rules with a single rule that always benchmarks
 	if *debugBenchmarkJS {
@@ -325,6 +324,7 @@ func main() {
 		"og-expiry-time", *ogTimeToLive,
 		"base-prefix", *basePrefix,
 		"cookie-expiration-time", *cookieExpiration,
+		"rule-error-ids", ruleErrorIDs,
 	)
 
 	go func() {

--- a/docs/docs/CHANGELOG.md
+++ b/docs/docs/CHANGELOG.md
@@ -12,13 +12,14 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ## [Unreleased]
 
 - Fixed native packages not containing the stdlib and botPolicies.yaml
+- Change import syntax to allow multi-level imports
+- Changed the startup logging to use JSON formatting as all the other logs do.
 
 ## v1.17.1: Asahi sas Brutus: Echo 1
 
 - Added customization of authorization cookie expiration time with `--cookie-expiration-time` flag or envvar
 - Updated the `OG_PASSTHROUGH` to be true by default, thereby allowing OpenGraph tags to be passed through by default
 - Added the ability to [customize Anubis' HTTP status codes](./admin/configuration/custom-status-codes.mdx) ([#355](https://github.com/TecharoHQ/anubis/issues/355))
-- Change import syntax to allow multi-level imports
 
 ## v1.17.0: Asahi sas Brutus
 


### PR DESCRIPTION
Noticed that Anubis prints something during startup that is not in the JSON format.
I moved the data into the "listening" log message.

Before:
```
Rule error IDs:
* ai-robots-txt: 8e399aa8f9f5d95a8cd0ad01284ea904784a854e9c6ab17ac9994f479d18aaed
* cloudflare-workers: 559e7f01707b78efda8b0ed791e13d0e0079fbf0e3c81c8dfaf2299537f8b666
* lightpanda: 8c4f381bde0fabcd361c88ec7f015d981fd7f80f3edcb16e670ed0bc772eb62d
* headless-chrome: b2dd0d54fa37a160ed04d152bcdde5df296a5861e0a6ef6a4fe845ef51d93be0
* headless-chromium: 900a0b88e9bcd4ae0772b55c198f6fb9e0e352da8af4ed61f7f72df1391f85a2
* us-artificial-intelligence-scraper: 5f0cb91e78d0499d22892c79e1520ccb378e98d3836effbd1ad675721bd46ac1

{"time":"2025-05-01T18:26:37.283704099+03:00","level":"WARN","source":{"function":"main.main","file":"/home/henri/src/anubis/cmd/anubis/main.go","line":259},"msg":"generating random key, Anubis will have strange behavior when multiple instances are behind the same load balancer target, for more information: see https://anubis.techaro.lol/docs/admin/installation#key-generation"}
{"time":"2025-05-01T18:26:37.283939179+03:00","level":"WARN","source":{"function":"main.main","file":"/home/henri/src/anubis/cmd/anubis/main.go","line":273},"msg":"REDIRECT_DOMAINS is not set, Anubis will only redirect to the same domain a request is coming from, see https://anubis.techaro.lol/docs/admin/configuration/redirect-domains"}
{"time":"2025-05-01T18:26:37.296666995+03:00","level":"INFO","source":{"function":"main.main","file":"/home/henri/src/anubis/cmd/anubis/main.go","line":315},"msg":"listening","url":"http://localhost:8923","difficulty":4,"serveRobotsTXT":false,"target":"http://localhost:3923","version":"devel","use-remote-address":false,"debug-benchmark-js":false,"og-passthrough":true,"og-expiry-time":86400000000000,"base-prefix":"","cookie-expiration-time":604800000000000}
```

After:
```json
{"time":"2025-05-01T18:28:08.608713376+03:00","level":"WARN","source":{"function":"main.main","file":"/home/henri/src/anubis/cmd/anubis/main.go","line":258},"msg":"generating random key, Anubis will have strange behavior when multiple instances are behind the same load balancer target, for more information: see https://anubis.techaro.lol/docs/admin/installation#key-generation"}
{"time":"2025-05-01T18:28:08.608832666+03:00","level":"WARN","source":{"function":"main.main","file":"/home/henri/src/anubis/cmd/anubis/main.go","line":272},"msg":"REDIRECT_DOMAINS is not set, Anubis will only redirect to the same domain a request is coming from, see https://anubis.techaro.lol/docs/admin/configuration/redirect-domains"}
{"time":"2025-05-01T18:28:08.620518085+03:00","level":"INFO","source":{"function":"main.main","file":"/home/henri/src/anubis/cmd/anubis/main.go","line":314},"msg":"listening","url":"http://localhost:8923","difficulty":4,"serveRobotsTXT":false,"target":"http://localhost:3923","version":"devel","use-remote-address":false,"debug-benchmark-js":false,"og-passthrough":true,"og-expiry-time":86400000000000,"base-prefix":"","cookie-expiration-time":604800000000000,"rule-error-ids":{"ai-robots-txt":"8e399aa8f9f5d95a8cd0ad01284ea904784a854e9c6ab17ac9994f479d18aaed","cloudflare-workers":"559e7f01707b78efda8b0ed791e13d0e0079fbf0e3c81c8dfaf2299537f8b666","headless-chrome":"b2dd0d54fa37a160ed04d152bcdde5df296a5861e0a6ef6a4fe845ef51d93be0","headless-chromium":"900a0b88e9bcd4ae0772b55c198f6fb9e0e352da8af4ed61f7f72df1391f85a2","lightpanda":"8c4f381bde0fabcd361c88ec7f015d981fd7f80f3edcb16e670ed0bc772eb62d","us-artificial-intelligence-scraper":"5f0cb91e78d0499d22892c79e1520ccb378e98d3836effbd1ad675721bd46ac1"}}
```

Now it is also possible to use something like jq to parse the logs:

```bash
go run ./cmd/anubis 2>&1 | jq .
```

Checklist:

- [x] Added a description of the changes to the `[Unreleased]` section of docs/docs/CHANGELOG.md
- [ ] Added test cases to [the relevant parts of the codebase](https://anubis.techaro.lol/docs/developer/code-quality)
- [x] Ran integration tests `npm run test:integration` (unsupported on Windows, please use WSL)
