### PR TITLE
fix(yeetfile): copy all docs, data files, and botPolicies.yaml

### DIFF
--- a/.github/workflows/package-builds-stable.yml
+++ b/.github/workflows/package-builds-stable.yml
@@ -64,7 +64,7 @@ jobs:
 
     - name: Build Packages
       run: |
-        wget https://github.com/TecharoHQ/yeet/releases/download/v0.2.1/yeet_0.2.1_amd64.deb -O var/yeet.deb
+        wget https://github.com/TecharoHQ/yeet/releases/download/v0.2.2/yeet_0.2.2_amd64.deb -O var/yeet.deb
         sudo apt -y install -f ./var/yeet.deb
         rm ./var/yeet.deb
         yeet

--- a/.github/workflows/package-builds-unstable.yml
+++ b/.github/workflows/package-builds-unstable.yml
@@ -66,7 +66,7 @@ jobs:
 
     - name: Build Packages
       run: |
-        wget https://github.com/TecharoHQ/yeet/releases/download/v0.2.1/yeet_0.2.1_amd64.deb -O var/yeet.deb
+        wget https://github.com/TecharoHQ/yeet/releases/download/v0.2.2/yeet_0.2.2_amd64.deb -O var/yeet.deb
         sudo apt -y install -f ./var/yeet.deb
         rm ./var/yeet.deb
         yeet

--- a/docs/docs/CHANGELOG.md
+++ b/docs/docs/CHANGELOG.md
@@ -11,6 +11,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+- Fixed native packages not containing the stdlib and botPolicies.yaml
+
 ## v1.17.1: Asahi sas Brutus: Echo 1
 
 - Added customization of authorization cookie expiration time with `--cookie-expiration-time` flag or envvar

--- a/yeetfile.js
+++ b/yeetfile.js
@@ -11,17 +11,24 @@ $`npm run assets`;
         documentation: {
             "./README.md": "README.md",
             "./LICENSE": "LICENSE",
-            "./docs/docs/CHANGELOG.md": "CHANGELOG.md",
-            "./docs/docs/admin/policies.mdx": "policies.md",
-            "./docs/docs/admin/native-install.mdx": "native-install.mdx",
             "./data/botPolicies.json": "botPolicies.json",
+            "./data/botPolicies.yaml": "botPolicies.yaml",
         },
 
-        build: ({ bin, etc, systemd, out }) => {
+        build: ({ bin, etc, systemd, doc }) => {
             $`go build -o ${bin}/anubis -ldflags '-s -w -extldflags "-static" -X "github.com/TecharoHQ/anubis.Version=${git.tag()}"' ./cmd/anubis`;
 
             file.install("./run/anubis@.service", `${systemd}/anubis@.service`);
             file.install("./run/default.env", `${etc}/default.env`);
+
+            $`mkdir -p ${doc}/docs`
+            $`cp -a docs/docs ${doc}`;
+            $`find ${doc} -name _category_.json -delete`;
+            $`mkdir -p ${doc}/data`;
+            $`cp -a data/apps ${doc}/data/apps`;
+            $`cp -a data/bots ${doc}/data/bots`;
+            $`cp -a data/common ${doc}/data/common`;
+            $`cp -a data/crawlers ${doc}/data/crawlers`;
         },
     }));
 });


### PR DESCRIPTION
Closes #415

This also bumps yeet to [v0.2.2](https://github.com/TecharoHQ/yeet/releases/tag/v0.2.2) to fix a minor bug with documentation files in the build function being written to the wrong folder.

Checklist:

- [x] Added a description of the changes to the `[Unreleased]` section of docs/docs/CHANGELOG.md
- [ ] Added test cases to [the relevant parts of the codebase](https://anubis.techaro.lol/docs/developer/code-quality)
- [ ] Ran integration tests `npm run test:integration` (unsupported on Windows, please use WSL)