### PR TITLE
test(playwright): Add Docker and Podman support

### DIFF
--- a/.github/actions/spelling/expect.txt
+++ b/.github/actions/spelling/expect.txt
@@ -117,6 +117,7 @@ loadbalancer
 lol
 maintainership
 malware
+mcr
 memes
 mimi
 minica
@@ -141,10 +142,13 @@ pids
 pipefail
 pki
 podkova
+podman
 prebaked
 privkey
 promauto
 promhttp
+pwcmd
+pwuser
 qwant
 qwantbot
 rac
@@ -196,6 +200,7 @@ webpage
 websecure
 websites
 workaround
+workdir
 xcaddy
 Xeact
 xeiaso

--- a/docs/docs/CHANGELOG.md
+++ b/docs/docs/CHANGELOG.md
@@ -14,6 +14,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Add `check-spelling` for spell checking
 - Add `--target-insecure-skip-verify` flag/envvar to allow Anubis to hit a self-signed HTTPS backend.
 - Minor adjustments to FreeBSD rc.d script to allow for more flexible configuration.
+- Added Podman and Docker support for running Playwright tests
 
 ## v1.18.0: Varis zos Galvus
 
@@ -69,7 +70,7 @@ Other changes:
 - Use CSS variables to deduplicate styles
 - Fixed native packages not containing the stdlib and botPolicies.yaml
 - Change import syntax to allow multi-level imports
-- Changed the startup logging to use JSON formatting as all the other logs do.
+- Changed the startup logging to use JSON formatting as all the other logs do
 - Added the ability to do [expression matching with CEL](./admin/configuration/expressions.mdx)
 - Add a warning for clients that don't store cookies
 - Disable Open Graph passthrough by default ([#435](https://github.com/TecharoHQ/anubis/issues/435))

--- a/package.json
+++ b/package.json
@@ -6,6 +6,8 @@
   "scripts": {
     "test": "npm run assets && go test ./...",
     "test:integration": "npm run assets && go test -v ./internal/test",
+    "test:integration:podman": "npm run assets && go test -v ./internal/test --playwright-runner=podman",
+    "test:integration:docker": "npm run assets && go test -v ./internal/test --playwright-runner=docker",
     "assets": "go generate ./... && ./web/build.sh && ./xess/build.sh",
     "build": "npm run assets && go build -o ./var/anubis ./cmd/anubis",
     "dev": "npm run assets && go run ./cmd/anubis --use-remote-address",


### PR DESCRIPTION
This PR allows running the Playwright server in a container, which makes it much easier to run, since it does not depend on the OS having installed some certain libraries or packages.

It uses the official Playwright image like it is explained in the [documentation](https://playwright.dev/docs/docker).

Checklist:

- [x] Added a description of the changes to the `[Unreleased]` section of docs/docs/CHANGELOG.md
- [ ] Added test cases to [the relevant parts of the codebase](https://anubis.techaro.lol/docs/developer/code-quality)
- [x] Ran integration tests `npm run test:integration`
- [x] Ran integration tests with Podman `npm run test:integration:podman`
- [x] Ran integration tests with Docker `npm run test:integration:docker`
