### PR TITLE
Fail immediately if pass-challenge is sent without cookie

### DIFF
--- a/docs/docs/CHANGELOG.md
+++ b/docs/docs/CHANGELOG.md
@@ -16,6 +16,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Change import syntax to allow multi-level imports
 - Changed the startup logging to use JSON formatting as all the other logs do.
 - Added the ability to do [expression matching with CEL](./admin/configuration/expressions.mdx)
+- Changed pass-challenge check to fail immediately if no cookie is set.
 
 ## v1.17.1: Asahi sas Brutus: Echo 1
 

--- a/lib/anubis.go
+++ b/lib/anubis.go
@@ -268,6 +268,14 @@ func (s *Server) PassChallenge(w http.ResponseWriter, r *http.Request) {
 	}
 	lg = lg.With("check_result", cr)
 
+	_, ckieErr := r.Cookie(anubis.CookieName)
+	if ckieErr != nil {
+		lg.Debug("cookie not found on passchallenge")
+		s.ClearCookie(w)
+		s.respondWithError(w, r, "cookie not provided")
+		return
+	}
+
 	nonceStr := r.FormValue("nonce")
 	if nonceStr == "" {
 		s.ClearCookie(w)

--- a/lib/http.go
+++ b/lib/http.go
@@ -17,8 +17,8 @@ func (s *Server) ClearCookie(w http.ResponseWriter) {
 	http.SetCookie(w, &http.Cookie{
 		Name:     anubis.CookieName,
 		Value:    "",
-		Expires:  time.Now().Add(-1 * time.Hour),
-		MaxAge:   -1,
+		Expires:  time.Now().Add(1 * time.Hour),
+		MaxAge:   3600,
 		SameSite: http.SameSiteLaxMode,
 		Domain:   s.opts.CookieDomain,
 	})


### PR DESCRIPTION
This is a straightforward way to test for cookie support in the user
agent. It doesn't change the behavior for any other user agents, but
browsers that have cookies disabled will show an error rather than
refreshing endlessly.

This fixes a common user complaint - #428 and also discussed on HN:
https://news.ycombinator.com/item?id=43865151

Most users don't block cookies entirely in their browser, but this
would help the few that do, and for users selectively enabling cookies
for certain sites, this will make allow-listing Anubis fronted sites
easier because the page will not be redirecting while they're trying
to allow the cookie to be set.

Checklist:

- [x] Added a description of the changes to the `[Unreleased]` section of docs/docs/CHANGELOG.md
- [ ] Added test cases to [the relevant parts of the codebase](https://anubis.techaro.lol/docs/developer/code-quality)
- [ ] Ran integration tests `npm run test:integration` (unsupported on Windows, please use WSL)
