### PR TITLE
feat(js): stop execution if the client disabled cookies

### DIFF
--- a/docs/docs/CHANGELOG.md
+++ b/docs/docs/CHANGELOG.md
@@ -16,6 +16,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Change import syntax to allow multi-level imports
 - Changed the startup logging to use JSON formatting as all the other logs do.
 - Added the ability to do [expression matching with CEL](./admin/configuration/expressions.mdx)
+- Add a warning for clients that don't store cookies
 
 ## v1.17.1: Asahi sas Brutus: Echo 1
 

--- a/web/js/main.mjs
+++ b/web/js/main.mjs
@@ -28,6 +28,11 @@ const dependencies = [
     msg: "Your browser doesn't support web workers (Anubis uses this to avoid freezing your browser). Do you have a plugin like JShelter installed?",
     value: window.Worker,
   },
+  {
+    name: "Cookies",
+    msg: "Your browser doesn't store cookies. Anubis uses cookies to determine which clients have passed challenges by storing a signed token in a cookie. Please enable storing cookies for this domain. The names of the cookies Anubis stores may vary without notice. Cookie names and values are not part of the public API.",
+    value: navigator.cookieEnabled,
+  },
 ];
 
 function showContinueBar(hash, nonce, t0, t1) {
@@ -131,6 +136,7 @@ function showContinueBar(hash, nonce, t0, t1) {
         statusMsg: msg,
         imageSrc: imageURL("reject", anubisVersion, basePrefix),
       });
+      return;
     }
   }
 


### PR DESCRIPTION
<!--
delete me and describe your change here, give enough context for a maintainer to understand what and why

See https://anubis.techaro.lol/docs/developer/code-quality for more information
-->

A better implementation of #437. This stops the client before proof of work runs.

Checklist:

- [x] Added a description of the changes to the `[Unreleased]` section of docs/docs/CHANGELOG.md
- [ ] Added test cases to [the relevant parts of the codebase](https://anubis.techaro.lol/docs/developer/code-quality)
- [ ] Ran integration tests `npm run test:integration` (unsupported on Windows, please use WSL)
