### PR TITLE
zizmor: add config file to silence unpinned-uses of Homebrew/actions

### DIFF
--- a/.github/zizmor.yml
+++ b/.github/zizmor.yml
@@ -1,0 +1,5 @@
+rules:
+  unpinned-uses:
+    config:
+      policies:
+        Homebrew/actions/*: any


### PR DESCRIPTION
This config silences warnings about Homebrew's actions being unpinned. We don't version those actions, so this will clear up some alerts.