### PR TITLE
Trim spaces from elements of split XFF string

### DIFF
--- a/internal/headers.go
+++ b/internal/headers.go
@@ -134,6 +134,9 @@ func computeXFFHeader(remoteAddr string, origXFFHeader string, pref XFFComputePr
 	origForwardedList := make([]string, 0, 4)
 	if origXFFHeader != "" {
 		origForwardedList = strings.Split(origXFFHeader, ",")
+		for i := range origForwardedList {
+			origForwardedList[i] = strings.TrimSpace(origForwardedList[i])
+		}
 	}
 	origForwardedList = append(origForwardedList, parsedRemoteIP.String())
 	forwardedList := make([]string, 0, len(origForwardedList))

--- a/internal/xff_test.go
+++ b/internal/xff_test.go
@@ -131,6 +131,19 @@ func TestComputeXFFHeader(t *testing.T) {
 			result: "1.1.1.1",
 		},
 		{
+			name:          "TrimSpaces",
+			remoteAddr:    "127.0.0.1:80",
+			origXFFHeader: "1.1.1.1, 10.0.0.1, fe80::, 100.64.0.1, 169.254.0.1",
+			pref: XFFComputePreferences{
+				StripPrivate:  true,
+				StripLoopback: true,
+				StripCGNAT:    true,
+				StripLLU:      true,
+				Flatten:       true,
+			},
+			result: "1.1.1.1",
+		},
+		{
 			name:       "invalid-ip-port",
 			remoteAddr: "fe80::",
 			err:        ErrCantSplitHostParse,


### PR DESCRIPTION
Fixed X-Forwarded-For parsing bug identified in #455 .

Checklist:

- [ ] Added a description of the changes to the `[Unreleased]` section of docs/docs/CHANGELOG.md
- [x] Added test cases to [the relevant parts of the codebase](https://anubis.techaro.lol/docs/developer/code-quality)
- [ ] Ran integration tests `npm run test:integration` (unsupported on Windows, please use WSL)
