### PR TITLE
docs: add missing subrequest auth configuration

### DIFF
--- a/docs/docs/admin/configuration/subrequest-auth.mdx
+++ b/docs/docs/admin/configuration/subrequest-auth.mdx
@@ -62,6 +62,11 @@ location /.within.website/ {
     # Assumption: Anubis is running in the same network namespace as
     # nginx on localhost TCP port 8923
     proxy_pass http://127.0.0.1:8923;
+    proxy_set_header X-Real-IP $remote_addr;
+    proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
+    proxy_set_header Host $http_host;
+    proxy_pass_request_body off;
+    proxy_set_header content-length "";
     auth_request off;
 }
 


### PR DESCRIPTION
* The IP address and Host should be included
* The Content-Length removed to avoid Anubis waiting for the body, which is not passed because subrequest is always using GET.

<!--
delete me and describe your change here, give enough context for a maintainer to understand what and why

See https://anubis.techaro.lol/docs/developer/code-quality for more information
-->

Checklist:

- [ ] Added a description of the changes to the `[Unreleased]` section of docs/docs/CHANGELOG.md
- [ ] Added test cases to [the relevant parts of the codebase](https://anubis.techaro.lol/docs/developer/code-quality)
- [ ] Ran integration tests `npm run test:integration` (unsupported on Windows, please use WSL)
