### PR TITLE
fix(lib): use a new cookie per domain when COOKIE_DOMAIN is set

### DIFF
--- a/anubis.go
+++ b/anubis.go
@@ -11,7 +11,10 @@ var Version = "devel"
 
 // CookieName is the name of the cookie that Anubis uses in order to validate
 // access.
-const CookieName = "within.website-x-cmd-anubis-auth"
+const CookieName = "techaro.lol-anubis-auth"
+
+// WithDomainCookieName is the name that is prepended to the per-domain cookie used when COOKIE_DOMAIN is set.
+const WithDomainCookieName = "techaro.lol-anubis-auth-for-"
 
 // CookieDefaultExpirationTime is the amount of time before the cookie/JWT expires.
 const CookieDefaultExpirationTime = 7 * 24 * time.Hour

--- a/docs/docs/CHANGELOG.md
+++ b/docs/docs/CHANGELOG.md
@@ -16,6 +16,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Minor adjustments to FreeBSD rc.d script to allow for more flexible configuration.
 - Added Podman and Docker support for running Playwright tests
 - Updated the nonce value in the challenge JWT cookie to be a string instead of a number
+- Rename cookies in response to user feedback
 
 ## v1.18.0: Varis zos Galvus
 
@@ -55,7 +56,7 @@ Or as complicated as:
 The docs have more information, but here's a tl;dr of the variables you have access to in expressions:
 
 | Name            | Type                  | Explanation                                                                                                                               | Example                                                      |
-|:----------------|:----------------------|:------------------------------------------------------------------------------------------------------------------------------------------|:-------------------------------------------------------------|
+| :-------------- | :-------------------- | :---------------------------------------------------------------------------------------------------------------------------------------- | :----------------------------------------------------------- |
 | `headers`       | `map[string, string]` | The [headers](https://developer.mozilla.org/en-US/docs/Web/HTTP/Reference/Headers) of the request being processed.                        | `{"User-Agent": "Mozilla/5.0 Gecko/20100101 Firefox/137.0"}` |
 | `host`          | `string`              | The [HTTP hostname](https://web.dev/articles/url-parts#host) the request is targeted to.                                                  | `anubis.techaro.lol`                                         |
 | `method`        | `string`              | The [HTTP method](https://developer.mozilla.org/en-US/docs/Web/HTTP/Reference/Methods) in the request being processed.                    | `GET`, `POST`, `DELETE`, etc.                                |

--- a/lib/anubis.go
+++ b/lib/anubis.go
@@ -67,6 +67,7 @@ type Server struct {
 	priv       ed25519.PrivateKey
 	pub        ed25519.PublicKey
 	opts       Options
+	cookieName string
 }
 
 func (s *Server) challengeFor(r *http.Request, difficulty int) string {
@@ -117,7 +118,7 @@ func (s *Server) maybeReverseProxy(w http.ResponseWriter, r *http.Request, httpS
 		return
 	}
 
-	ckie, err := r.Cookie(anubis.CookieName)
+	ckie, err := r.Cookie(s.cookieName)
 	if err != nil {
 		lg.Debug("cookie not found", "path", r.URL.Path)
 		s.ClearCookie(w)
@@ -360,7 +361,7 @@ func (s *Server) PassChallenge(w http.ResponseWriter, r *http.Request) {
 	}
 
 	http.SetCookie(w, &http.Cookie{
-		Name:        anubis.CookieName,
+		Name:        s.cookieName,
 		Value:       tokenString,
 		Expires:     time.Now().Add(s.opts.CookieExpiration),
 		SameSite:    http.SameSiteLaxMode,

--- a/lib/anubis_test.go
+++ b/lib/anubis_test.go
@@ -198,13 +198,13 @@ func TestCookieCustomExpiration(t *testing.T) {
 	var ckie *http.Cookie
 	for _, cookie := range resp.Cookies() {
 		t.Logf("%#v", cookie)
-		if cookie.Name == anubis.CookieName {
+		if cookie.Name == srv.cookieName {
 			ckie = cookie
 			break
 		}
 	}
 	if ckie == nil {
-		t.Errorf("Cookie %q not found", anubis.CookieName)
+		t.Errorf("Cookie %q not found", srv.cookieName)
 		return
 	}
 
@@ -288,13 +288,13 @@ func TestCookieSettings(t *testing.T) {
 	var ckie *http.Cookie
 	for _, cookie := range resp.Cookies() {
 		t.Logf("%#v", cookie)
-		if cookie.Name == anubis.CookieName {
+		if cookie.Name == srv.cookieName {
 			ckie = cookie
 			break
 		}
 	}
 	if ckie == nil {
-		t.Errorf("Cookie %q not found", anubis.CookieName)
+		t.Errorf("Cookie %q not found", srv.cookieName)
 		return
 	}
 

--- a/lib/config.go
+++ b/lib/config.go
@@ -81,6 +81,12 @@ func New(opts Options) (*Server, error) {
 
 	anubis.BasePrefix = opts.BasePrefix
 
+	cookieName := anubis.CookieName
+
+	if opts.CookieDomain != "" {
+		cookieName = anubis.WithDomainCookieName + opts.CookieDomain
+	}
+
 	result := &Server{
 		next:       opts.Next,
 		priv:       opts.PrivateKey,
@@ -89,6 +95,7 @@ func New(opts Options) (*Server, error) {
 		opts:       opts,
 		DNSBLCache: decaymap.New[string, dnsbl.DroneBLResponse](),
 		OGTags:     ogtags.NewOGTagCache(opts.Target, opts.OGPassthrough, opts.OGTimeToLive, opts.OGCacheConsidersHost),
+		cookieName: cookieName,
 	}
 
 	mux := http.NewServeMux()


### PR DESCRIPTION
Closes #315 

Also properly re-brand the cookies so that some of the /x/ heritage is lost.

Checklist:

- [x] Added a description of the changes to the `[Unreleased]` section of docs/docs/CHANGELOG.md
- [x] Added test cases to [the relevant parts of the codebase](https://anubis.techaro.lol/docs/developer/code-quality)
- [x] Ran integration tests `npm run test:integration` (unsupported on Windows, please use WSL)
