### PR TITLE
fix(lib): make ClearCookie respect the dynamic cookie name

### DIFF
--- a/docs/docs/CHANGELOG.md
+++ b/docs/docs/CHANGELOG.md
@@ -17,6 +17,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Added Podman and Docker support for running Playwright tests
 - Updated the nonce value in the challenge JWT cookie to be a string instead of a number
 - Rename cookies in response to user feedback
+- Ensure cookie renaming is consistent across configuration options
 
 ## v1.18.0: Varis zos Galvus
 

--- a/lib/http.go
+++ b/lib/http.go
@@ -9,13 +9,11 @@ import (
 	"github.com/TecharoHQ/anubis/lib/policy"
 	"github.com/TecharoHQ/anubis/web"
 	"github.com/a-h/templ"
-
-	"github.com/TecharoHQ/anubis"
 )
 
 func (s *Server) ClearCookie(w http.ResponseWriter) {
 	http.SetCookie(w, &http.Cookie{
-		Name:     anubis.CookieName,
+		Name:     s.cookieName,
 		Value:    "",
 		Expires:  time.Now().Add(-1 * time.Hour),
 		MaxAge:   -1,

--- a/lib/http_test.go
+++ b/lib/http_test.go
@@ -1,0 +1,58 @@
+package lib
+
+import (
+	"net/http/httptest"
+	"testing"
+
+	"github.com/TecharoHQ/anubis"
+)
+
+func TestClearCookie(t *testing.T) {
+	srv := spawnAnubis(t, Options{})
+	rw := httptest.NewRecorder()
+
+	srv.ClearCookie(rw)
+
+	resp := rw.Result()
+
+	cookies := resp.Cookies()
+
+	if len(cookies) != 1 {
+		t.Errorf("wanted 1 cookie, got %d cookies", len(cookies))
+	}
+
+	ckie := cookies[0]
+
+	if ckie.Name != anubis.CookieName {
+		t.Errorf("wanted cookie named %q, got cookie named %q", anubis.CookieName, ckie.Name)
+	}
+
+	if ckie.MaxAge != -1 {
+		t.Errorf("wanted cookie max age of -1, got: %d", ckie.MaxAge)
+	}
+}
+
+func TestClearCookieWithDomain(t *testing.T) {
+	srv := spawnAnubis(t, Options{CookieDomain: "techaro.lol"})
+	rw := httptest.NewRecorder()
+
+	srv.ClearCookie(rw)
+
+	resp := rw.Result()
+
+	cookies := resp.Cookies()
+
+	if len(cookies) != 1 {
+		t.Errorf("wanted 1 cookie, got %d cookies", len(cookies))
+	}
+
+	ckie := cookies[0]
+
+	if ckie.Name != srv.cookieName {
+		t.Errorf("wanted cookie named %q, got cookie named %q", srv.cookieName, ckie.Name)
+	}
+
+	if ckie.MaxAge != -1 {
+		t.Errorf("wanted cookie max age of -1, got: %d", ckie.MaxAge)
+	}
+}


### PR DESCRIPTION
Previously this made ClearCookie always clear cookies by name even when CookieDomain was set. This change fixes this and adds tests to make sure that this doesn't happen again.

Checklist:

- [x] Added a description of the changes to the `[Unreleased]` section of docs/docs/CHANGELOG.md
- [x] Added test cases to [the relevant parts of the codebase](https://anubis.techaro.lol/docs/developer/code-quality)
- [x] Ran integration tests `npm run test:integration` (unsupported on Windows, please use WSL)
