### PR TITLE
feat(apps): add Qualys SSL Labs policy

### DIFF
--- a/data/apps/qualys-ssl-labs.yml
+++ b/data/apps/qualys-ssl-labs.yml
@@ -1,0 +1,7 @@
+# This policy allows Qualys SSL Labs to fully work. (https://www.ssllabs.com/ssltest)
+# IP ranges are taken from: https://qualys.my.site.com/discussions/s/article/000005823
+- name: qualys-ssl-labs
+  action: ALLOW
+  remote_addresses:
+  - 64.41.200.0/24
+  - 2600:C02:1020:4202::/64

--- a/docs/docs/CHANGELOG.md
+++ b/docs/docs/CHANGELOG.md
@@ -18,6 +18,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Updated the nonce value in the challenge JWT cookie to be a string instead of a number
 - Rename cookies in response to user feedback
 - Ensure cookie renaming is consistent across configuration options
+- Added Qualys SSL Labs whitelist policy
 
 ## v1.18.0: Varis zos Galvus
 


### PR DESCRIPTION
This policy adds support for [SSL Labs](https://www.ssllabs.com/ssltest/). Needed to run this test and realized I didn't have it whitelisted, so this is here if anyone else needs it.

Checklist:

- [x] Added a description of the changes to the `[Unreleased]` section of docs/docs/CHANGELOG.md
- [ ] Added test cases to [the relevant parts of the codebase](https://anubis.techaro.lol/docs/developer/code-quality)
- [ ] Ran integration tests `npm run test:integration` (unsupported on Windows, please use WSL)
