### PR TITLE
feat(apps): add SearXNG instance tracker policy

### DIFF
--- a/data/apps/searx-checker.yml
+++ b/data/apps/searx-checker.yml
@@ -1,0 +1,9 @@
+# This policy allows SearXNG's instance tracker to work. (https://searx.space)
+# IPs are taken from `check.searx.space` DNS records.
+# https://toolbox.googleapps.com/apps/dig/#A/check.searx.space
+# https://toolbox.googleapps.com/apps/dig/#AAAA/check.searx.space
+- name: searx-checker
+  action: ALLOW
+  remote_addresses:
+  - 167.235.158.251/32
+  - 2a01:4f8:1c1c:8fc2::1/128

--- a/docs/docs/CHANGELOG.md
+++ b/docs/docs/CHANGELOG.md
@@ -18,6 +18,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Updated the nonce value in the challenge JWT cookie to be a string instead of a number
 - Rename cookies in response to user feedback
 - Ensure cookie renaming is consistent across configuration options
+- Added SearXNG instance tracker whitelist policy
 
 ## v1.18.0: Varis zos Galvus
 


### PR DESCRIPTION
This policy adds support for [SearXNG's instance tracker](https://searx.space/). Made this myself a bit ago so this site can access my SearXNG instance correctly. Making this a policy just in case anyone else needs it.

Checklist:

- [x] Added a description of the changes to the `[Unreleased]` section of docs/docs/CHANGELOG.md
- [ ] Added test cases to [the relevant parts of the codebase](https://anubis.techaro.lol/docs/developer/code-quality)
- [ ] Ran integration tests `npm run test:integration` (unsupported on Windows, please use WSL)
