### PR TITLE
fix(systemd): add RuntimeDirectory

### DIFF
--- a/docs/docs/CHANGELOG.md
+++ b/docs/docs/CHANGELOG.md
@@ -18,6 +18,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Updated the nonce value in the challenge JWT cookie to be a string instead of a number
 - Rename cookies in response to user feedback
 - Ensure cookie renaming is consistent across configuration options
+- Add `RuntimeDirectory` to systemd unit settings so native packages can listen over unix sockets
 
 ## v1.18.0: Varis zos Galvus
 

--- a/run/anubis@.service
+++ b/run/anubis@.service
@@ -12,6 +12,8 @@ CacheDirectory=anubis/%i
 CacheDirectoryMode=0755
 StateDirectory=anubis/%i
 StateDirectoryMode=0755
+RuntimeDirectory=anubis
+RuntimeDirectoryMode=0755
 ReadWritePaths=/run
 
 [Install]


### PR DESCRIPTION
Closes #508

Notably, this makes the Anubis RuntimeDirectory `/run/anubis` instead of `/run/anubis/%i`. I don't think this is confusing in practice, but it could come up as weird.

Checklist:

- [x] Added a description of the changes to the `[Unreleased]` section of docs/docs/CHANGELOG.md
- [ ] Added test cases to [the relevant parts of the codebase](https://anubis.techaro.lol/docs/developer/code-quality)
- [ ] Ran integration tests `npm run test:integration` (unsupported on Windows, please use WSL)
