### PR TITLE
Add reddit.nerdvpn.de to known instances

### DIFF
--- a/docs/docs/user/known-instances.md
+++ b/docs/docs/user/known-instances.md
@@ -34,6 +34,7 @@ This page contains a non-exhaustive list with all websites using Anubis.
 - https://bugzilla.proxmox.com
 - https://hofstede.io/
 - https://www.indiemag.fr/
+- https://reddit.nerdvpn.de/
 - <details>
   <summary>FreeCAD</summary>
   - https://forum.freecad.org/


### PR DESCRIPTION
Simply adds https://reddit.nerdvpn.de to the list of known instances in the docs since I saw Anubis there. It might also be used on other services hosted on nerdvpn.de, but I didn't get it to appear anywhere else. There probably is a better way to check that I'm not aware of, so feel free to do that.

Checklist:

- [ ] Added a description of the changes to the `[Unreleased]` section of docs/docs/CHANGELOG.md
- [ ] Added test cases to [the relevant parts of the codebase](https://anubis.techaro.lol/docs/developer/code-quality)
- [ ] Ran integration tests `npm run test:integration` (unsupported on Windows, please use WSL)

The checklist doesn't really apply here, does it? Or are documentation edits also listed in CHANGELOG.md?
