### PR TITLE
fix(lib): properly clear out test cookie

### DIFF
--- a/docs/docs/CHANGELOG.md
+++ b/docs/docs/CHANGELOG.md
@@ -26,6 +26,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Add `RuntimeDirectory` to systemd unit settings so native packages can listen over unix sockets
 - Added SearXNG instance tracker whitelist policy
 - Added Qualys SSL Labs whitelist policy
+- Fixed cookie deletion logic ([#520](https://github.com/TecharoHQ/anubis/issues/520), [#522](https://github.com/TecharoHQ/anubis/pull/522))
 
 ## v1.18.0: Varis zos Galvus
 

--- a/lib/http.go
+++ b/lib/http.go
@@ -26,14 +26,16 @@ func (s *Server) SetCookie(w http.ResponseWriter, name, value, path string) {
 	})
 }
 
-func (s *Server) ClearCookie(w http.ResponseWriter, name string) {
+func (s *Server) ClearCookie(w http.ResponseWriter, name, path string) {
 	http.SetCookie(w, &http.Cookie{
-		Name:     name,
-		Value:    "",
-		Expires:  time.Now().Add(-1 * time.Hour),
-		MaxAge:   -1,
-		SameSite: http.SameSiteLaxMode,
-		Domain:   s.opts.CookieDomain,
+		Name:        name,
+		Value:       "",
+		MaxAge:      -1,
+		Expires:     time.Now().Add(-1 * time.Minute),
+		SameSite:    http.SameSiteLaxMode,
+		Partitioned: s.opts.CookiePartitioned,
+		Domain:      s.opts.CookieDomain,
+		Path:        path,
 	})
 }
 
@@ -82,7 +84,12 @@ func (s *Server) RenderIndex(w http.ResponseWriter, r *http.Request, rule *polic
 		}
 	}
 
-	s.SetCookie(w, anubis.TestCookieName, challenge, "")
+	http.SetCookie(w, &http.Cookie{
+		Name:    anubis.TestCookieName,
+		Value:   challenge,
+		Expires: time.Now().Add(30 * time.Minute),
+		Path:    "/",
+	})
 
 	component, err := web.BaseWithChallengeAndOGTags("Making sure you're not a bot!", web.Index(), challenge, rule.Challenge, ogTags)
 	if err != nil {

--- a/lib/http_test.go
+++ b/lib/http_test.go
@@ -11,7 +11,7 @@ func TestClearCookie(t *testing.T) {
 	srv := spawnAnubis(t, Options{})
 	rw := httptest.NewRecorder()
 
-	srv.ClearCookie(rw, srv.cookieName)
+	srv.ClearCookie(rw, srv.cookieName, "/")
 
 	resp := rw.Result()
 
@@ -36,7 +36,7 @@ func TestClearCookieWithDomain(t *testing.T) {
 	srv := spawnAnubis(t, Options{CookieDomain: "techaro.lol"})
 	rw := httptest.NewRecorder()
 
-	srv.ClearCookie(rw, srv.cookieName)
+	srv.ClearCookie(rw, srv.cookieName, "/")
 
 	resp := rw.Result()
 


### PR DESCRIPTION
Closes #520

For some reason, Chrome and Firefox are very picky over what they use to match cookies that need to be deleted. Listen to me for my tale of woe:

The basic problem here is that cookies were an early hack added on the side of the HTTP spec and they're basically impossible to upgrade or change because who knows what relies on the exact behavior cookies use. As a result, cookies don't just match by name, but by every setting that exists on them. You can also have two cookies with the same name but different values. This spec is a nightmare lol.

Even more fun: browsers will make up values for cookies if they aren't set, meaning that getting a challenge token at `/docs` is semantically different than a challenge token you got from `/`.

This PR fixes this issue by explicitly setting the "make sure cookie support is working" cookie's path to `/`, meaning that it will always be sent. Additionally, cookies are expired by setting the expiry time to one minute in the past.

Hopefully this will fix it. I'm testing this locally and it seems to work fine.

<!--
delete me and describe your change here, give enough context for a maintainer to understand what and why

See https://anubis.techaro.lol/docs/developer/code-quality for more information
-->

Checklist:

- [ ] Added a description of the changes to the `[Unreleased]` section of docs/docs/CHANGELOG.md
- [ ] Added test cases to [the relevant parts of the codebase](https://anubis.techaro.lol/docs/developer/code-quality)
- [ ] Ran integration tests `npm run test:integration` (unsupported on Windows, please use WSL)
