### PR TITLE
feat: add TARGET_SNI to allow overriding the TLS handshake hostname when forwarding requests

### DIFF
--- a/.github/actions/spelling/expect.txt
+++ b/.github/actions/spelling/expect.txt
@@ -178,6 +178,7 @@ selfsigned
 setsebool
 sitemap
 sls
+sni
 Sourceware
 Spambot
 sparkline

--- a/docs/docs/CHANGELOG.md
+++ b/docs/docs/CHANGELOG.md
@@ -27,6 +27,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Added SearXNG instance tracker whitelist policy
 - Added Qualys SSL Labs whitelist policy
 - Fixed cookie deletion logic ([#520](https://github.com/TecharoHQ/anubis/issues/520), [#522](https://github.com/TecharoHQ/anubis/pull/522))
+- Add `--target-sni` flag/envvar to allow changing the value of the TLS handshake hostname in requests forwarded to the target service.
 
 ## v1.18.0: Varis zos Galvus
 

--- a/docs/docs/admin/installation.mdx
+++ b/docs/docs/admin/installation.mdx
@@ -84,6 +84,7 @@ If you don't know or understand what these settings mean, ignore them. These are
 
 | Environment Variable          | Default value | Explanation                                                                                                                                         |
 | :---------------------------- | :------------ | :-------------------------------------------------------------------------------------------------------------------------------------------------- |
+| `TARGET_SNI`                  | unset         | If set, overrides the TLS handshake hostname in requests forwarded to `TARGET`.                                                                     |
 | `TARGET_HOST`                 | unset         | If set, overrides the Host header in requests forwarded to `TARGET`.                                                                                |
 | `TARGET_INSECURE_SKIP_VERIFY` | `false`       | If `true`, skip TLS certificate validation for targets that listen over `https`. If your backend does not listen over `https`, ignore this setting. |
 


### PR DESCRIPTION
When running Anubis in front of a site that's served from a different host, it's nice to be able to specify HTTPS for the `TARGET` and stay end-to-end encrypted.

If that backend server is shared hosting, then the site's own hostname may be the only one that's correct to specify in the TLS handshake (SNI) - but it will be different than the hostname Anubis needs to resolve and connect to.

For example, let's say the site is `site1.example.com` and its backend server is `backend.example.com`. DNS for `site1` points at Anubis, not the backend server. `https://backend.example.com` is the appropriate `TARGET`, but it hosts tons of other sites. If Anubis' handshake and Host header ask for `backend.example.com` it'll serve its default site (wrong), and if Anubis' handshake and Host header mismatch it'll probably serve a 421 Misdirected Request.

You could work around this by naming the site `site1-backend.example.com` on the backend server and adding that to DNS, but there are configurations where this isn't easy or elegant to do.

So, adding `TARGET_SNI` allows Anubis to handle this. This is very similar to #507, but I can imagine scenarios where you might want one without the other.

I chose to write nested `if` statements so that we customize `TLSClientConfig` only when needed.

Checklist:

- [x] Added a description of the changes to the `[Unreleased]` section of docs/docs/CHANGELOG.md
- [ ] Added test cases to [the relevant parts of the codebase](https://anubis.techaro.lol/docs/developer/code-quality)
- [ ] Ran integration tests `npm run test:integration` (unsupported on Windows, please use WSL)
