### PR TITLE
docs: correct the path for the default configuration file

### DIFF
--- a/.github/actions/spelling/expect.txt
+++ b/.github/actions/spelling/expect.txt
@@ -210,7 +210,7 @@ webmaster
 webpage
 websecure
 websites
-workaround
+Workaround
 workdir
 xcaddy
 Xeact

--- a/docs/docs/admin/native-install.mdx
+++ b/docs/docs/admin/native-install.mdx
@@ -49,7 +49,7 @@ sudo install -D ./run/anubis@.service /etc/systemd/system
 Install the default configuration file to your system:
 
 ```text
-sudo install -D ./run/default.env /etc/anubis
+sudo install -D ./run/default.env /etc/anubis/default.env
 ```
 
   </TabItem>


### PR DESCRIPTION
Using the native-install instructions, default.env was installed as /etc/anubis rather than /etc/anubis/default.env

I created an issue before I decided to just make a PR: #534 

Would you like me to add an entry into the changelog for a typo fix?

Closes #534 

Checklist:

- [ ] Added a description of the changes to the `[Unreleased]` section of docs/docs/CHANGELOG.md
- [ ] ~Added test cases to [the relevant parts of the codebase](https://anubis.techaro.lol/docs/developer/code-quality)~
- [ ] ~Ran integration tests `npm run test:integration` (unsupported on Windows, please use WSL)~
