### PR TITLE
fix(lib): record challenges issused over embedded HTML

### DIFF
--- a/docs/docs/CHANGELOG.md
+++ b/docs/docs/CHANGELOG.md
@@ -11,6 +11,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+- Record if challenges were issued via the API or via embedded JSON in the challenge page HTML ([#531](https://github.com/TecharoHQ/anubis/issues/531))
 - Ensure that clients that are shown a challenge support storing cookies
 - Encode challenge pages with gzip level 1
 - Add `check-spelling` for spell checking

--- a/lib/anubis.go
+++ b/lib/anubis.go
@@ -31,10 +31,10 @@ import (
 )
 
 var (
-	challengesIssued = promauto.NewCounter(prometheus.CounterOpts{
+	challengesIssued = promauto.NewCounterVec(prometheus.CounterOpts{
 		Name: "anubis_challenges_issued",
 		Help: "The total number of challenges issued",
-	})
+	}, []string{"method"})
 
 	challengesValidated = promauto.NewCounter(prometheus.CounterOpts{
 		Name: "anubis_challenges_validated",
@@ -260,7 +260,7 @@ func (s *Server) MakeChallenge(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 	lg.Debug("made challenge", "challenge", challenge, "rules", rule.Challenge, "cr", cr)
-	challengesIssued.Inc()
+	challengesIssued.WithLabelValues("api").Inc()
 }
 
 func (s *Server) PassChallenge(w http.ResponseWriter, r *http.Request) {

--- a/lib/http.go
+++ b/lib/http.go
@@ -73,6 +73,7 @@ func (s *Server) RenderIndex(w http.ResponseWriter, r *http.Request, rule *polic
 		s.respondWithError(w, r, "Client Error: Please ensure your browser is up to date and try again later.")
 	}
 
+	challengesIssued.WithLabelValues("embedded").Add(1)
 	challenge := s.challengeFor(r, rule.Challenge.Difficulty)
 
 	var ogTags map[string]string = nil


### PR DESCRIPTION
Closes #531

This changes `anubis_challenges_issued` to be a vector counter that records the challenge issuance method.

<!--
delete me and describe your change here, give enough context for a maintainer to understand what and why

See https://anubis.techaro.lol/docs/developer/code-quality for more information
-->

Checklist:

- [x] Added a description of the changes to the `[Unreleased]` section of docs/docs/CHANGELOG.md
- [ ] Added test cases to [the relevant parts of the codebase](https://anubis.techaro.lol/docs/developer/code-quality)
- [ ] Ran integration tests `npm run test:integration` (unsupported on Windows, please use WSL)
