### PR TITLE
feat(metrics): add basic request metric suppport

### DIFF
--- a/docs/docs/CHANGELOG.md
+++ b/docs/docs/CHANGELOG.md
@@ -33,6 +33,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Add `--target-sni` flag/envvar to allow changing the value of the TLS handshake hostname in requests forwarded to the target service.
 - Fixed CEL expression matching validator to now properly error out when it receives empty expressions
 - Added OpenRC init.d script.
+- Added basic request metrics
 
 ## v1.18.0: Varis zos Galvus
 


### PR DESCRIPTION
This commit adds basic metrics for http request results. This can be used to monitor which amount of traffic is denied or allowed.

I still have to figure out how to run the integration tests.

Checklist:

- [x] Added a description of the changes to the `[Unreleased]` section of docs/docs/CHANGELOG.md
- [ ] Added test cases to [the relevant parts of the codebase](https://anubis.techaro.lol/docs/developer/code-quality)
- [ ] Ran integration tests `npm run test:integration` (unsupported on Windows, please use WSL)
