### PR TITLE
feat(cli): Add --version flag

### DIFF
--- a/cmd/anubis/main.go
+++ b/cmd/anubis/main.go
@@ -67,6 +67,7 @@ var (
 	ogCacheConsiderHost      = flag.Bool("og-cache-consider-host", false, "enable or disable the use of the host in the Open Graph tag cache")
 	extractResources         = flag.String("extract-resources", "", "if set, extract the static resources to the specified folder")
 	webmasterEmail           = flag.String("webmaster-email", "", "if set, displays webmaster's email on the reject page for appeals")
+	versionFlag              = flag.Bool("version", false, "print Anubis version")
 )
 
 func keyFromHex(value string) (ed25519.PrivateKey, error) {
@@ -201,6 +202,11 @@ func startDecayMapCleanup(ctx context.Context, s *libanubis.Server) {
 func main() {
 	flagenv.Parse()
 	flag.Parse()
+
+	if *versionFlag {
+		fmt.Println("Anubis", anubis.Version)
+		return
+	}
 
 	internal.InitSlog(*slogLevel)
 

--- a/docs/docs/CHANGELOG.md
+++ b/docs/docs/CHANGELOG.md
@@ -33,6 +33,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Add `--target-sni` flag/envvar to allow changing the value of the TLS handshake hostname in requests forwarded to the target service.
 - Fixed CEL expression matching validator to now properly error out when it receives empty expressions
 - Added OpenRC init.d script.
+- Added `--version` flag.
 
 ## v1.18.0: Varis zos Galvus
 


### PR DESCRIPTION
Closes #559.

Adds a `--version` flag which prints a line of the format `Anubis <version>` (e.g. `Anubis v1.19.0-pre1`) and then exits.

Checklist:

- [x] Added a description of the changes to the `[Unreleased]` section of docs/docs/CHANGELOG.md
- [ ] Added test cases to [the relevant parts of the codebase](https://anubis.techaro.lol/docs/developer/code-quality)
- [x] Ran integration tests `npm run test:integration` (unsupported on Windows, please use WSL)
