### PR TITLE
feat(lib): annotate cookies with what rule was passed

### DIFF
--- a/lib/anubis.go
+++ b/lib/anubis.go
@@ -474,6 +474,7 @@ func (s *Server) check(r *http.Request) (policy.CheckResult, *policy.Bot, error)
 			ReportAs:   s.policy.DefaultDifficulty,
 			Algorithm:  config.AlgorithmFast,
 		},
+		Rules: &policy.CheckerList{},
 	}, nil
 }
 

--- a/lib/anubis.go
+++ b/lib/anubis.go
@@ -162,6 +162,29 @@ func (s *Server) maybeReverseProxy(w http.ResponseWriter, r *http.Request, httpS
 		return
 	}
 
+	claims, ok := token.Claims.(jwt.MapClaims)
+	if !ok {
+		lg.Debug("invalid token claims type", "path", r.URL.Path)
+		s.ClearCookie(w, s.cookieName, cookiePath)
+		s.RenderIndex(w, r, rule, httpStatusOnly)
+		return
+	}
+
+	policyRule, ok := claims["policyRule"].(string)
+	if !ok {
+		lg.Debug("policyRule claim is not a string")
+		s.ClearCookie(w, s.cookieName, cookiePath)
+		s.RenderIndex(w, r, rule, httpStatusOnly)
+		return
+	}
+
+	if policyRule != rule.Hash() {
+		lg.Debug("user originally passed with a different rule, issuing new challenge", "old", policyRule, "new", rule.Name)
+		s.ClearCookie(w, s.cookieName, cookiePath)
+		s.RenderIndex(w, r, rule, httpStatusOnly)
+		return
+	}
+
 	r.Header.Add("X-Anubis-Status", "PASS")
 	s.ServeHTTPNext(w, r)
 }
@@ -230,6 +253,21 @@ func (s *Server) handleDNSBL(w http.ResponseWriter, r *http.Request, ip string, 
 
 func (s *Server) MakeChallenge(w http.ResponseWriter, r *http.Request) {
 	lg := internal.GetRequestLogger(r)
+
+	redir := r.FormValue("redir")
+	if redir == "" {
+		w.WriteHeader(http.StatusBadRequest)
+		encoder := json.NewEncoder(w)
+		lg.Error("invalid invocation of MakeChallenge", "redir", redir)
+		encoder.Encode(struct {
+			Error string `json:"error"`
+		}{
+			Error: "Invalid invocation of MakeChallenge",
+		})
+		return
+	}
+
+	r.URL.Path = redir
 
 	encoder := json.NewEncoder(w)
 	cr, rule, err := s.check(r)
@@ -374,15 +412,13 @@ func (s *Server) PassChallenge(w http.ResponseWriter, r *http.Request) {
 	}
 
 	// generate JWT cookie
-	token := jwt.NewWithClaims(jwt.SigningMethodEdDSA, jwt.MapClaims{
-		"challenge": challenge,
-		"nonce":     nonceStr,
-		"response":  response,
-		"iat":       time.Now().Unix(),
-		"nbf":       time.Now().Add(-1 * time.Minute).Unix(),
-		"exp":       time.Now().Add(s.opts.CookieExpiration).Unix(),
+	tokenString, err := s.signJWT(jwt.MapClaims{
+		"challenge":  challenge,
+		"nonce":      nonceStr,
+		"response":   response,
+		"policyRule": rule.Hash(),
+		"action":     string(cr.Rule),
 	})
-	tokenString, err := token.SignedString(s.priv)
 	if err != nil {
 		lg.Error("failed to sign JWT", "err", err)
 		s.ClearCookie(w, s.cookieName, cookiePath)

--- a/lib/http.go
+++ b/lib/http.go
@@ -12,6 +12,7 @@ import (
 	"github.com/TecharoHQ/anubis/lib/policy"
 	"github.com/TecharoHQ/anubis/web"
 	"github.com/a-h/templ"
+	"github.com/golang-jwt/jwt/v5"
 )
 
 func (s *Server) SetCookie(w http.ResponseWriter, name, value, path string) {
@@ -150,4 +151,12 @@ func (s *Server) ServeHTTPNext(w http.ResponseWriter, r *http.Request) {
 		requestsProxied.WithLabelValues(r.Host).Inc()
 		s.next.ServeHTTP(w, r)
 	}
+}
+
+func (s *Server) signJWT(claims jwt.MapClaims) (string, error) {
+	claims["iat"] = time.Now().Unix()
+	claims["nbf"] = time.Now().Add(-1 * time.Minute).Unix()
+	claims["exp"] = time.Now().Add(s.opts.CookieExpiration).Unix()
+
+	return jwt.NewWithClaims(jwt.SigningMethodEdDSA, claims).SignedString(s.priv)
 }

--- a/lib/testdata/rule_change.yaml
+++ b/lib/testdata/rule_change.yaml
@@ -1,0 +1,12 @@
+bots:
+- name: old-rule
+  path_regex: ^/old$
+  action: CHALLENGE
+
+- name: new-rule
+  path_regex: ^/new$
+  action: CHALLENGE
+
+status_codes:
+  CHALLENGE: 401
+  DENY: 403


### PR DESCRIPTION
This is an attempt to work around an issue where clients get accepted at one challenge level for one route and then visit a different route at another challenge level without having to pass a challenge again.

Checklist:

- [ ] Added a description of the changes to the `[Unreleased]` section of docs/docs/CHANGELOG.md
- [ ] Added test cases to [the relevant parts of the codebase](https://anubis.techaro.lol/docs/developer/code-quality)
- [ ] Ran integration tests `npm run test:integration` (unsupported on Windows, please use WSL)
