### PR TITLE
fix(lib): only use the first five characters of Accept-Language header values

### DIFF
--- a/docs/docs/CHANGELOG.md
+++ b/docs/docs/CHANGELOG.md
@@ -27,6 +27,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Rename cookies in response to user feedback
 - Ensure cookie renaming is consistent across configuration options
 - Add Bookstack app in data
+- Truncate everything but the first five characters of Accept-Language headers when making challenges
 - Ensure client JavaScript is served with Content-Type text/javascript.
 - Add `--target-host` flag/envvar to allow changing the value of the Host header in requests forwarded to the target service.
 - Bump AI-robots.txt to version 1.31

--- a/lib/anubis.go
+++ b/lib/anubis.go
@@ -76,11 +76,16 @@ type Server struct {
 }
 
 func (s *Server) challengeFor(r *http.Request, difficulty int) string {
-	fp := sha256.Sum256(s.priv.Seed())
+	fp := sha256.Sum256(s.pub[:])
+
+	acceptLanguage := r.Header.Get("Accept-Language")
+	if len(acceptLanguage) > 5 {
+		acceptLanguage = acceptLanguage[:5]
+	}
 
 	challengeData := fmt.Sprintf(
 		"Accept-Language=%s,X-Real-IP=%s,User-Agent=%s,WeekTime=%s,Fingerprint=%x,Difficulty=%d",
-		r.Header.Get("Accept-Language"),
+		acceptLanguage,
 		r.Header.Get("X-Real-Ip"),
 		r.UserAgent(),
 		time.Now().UTC().Round(24*7*time.Hour).Format(time.RFC3339),


### PR DESCRIPTION
For some reason, Google Chrome will randomly send a "full" Accept-Language header, and other times it will send a "partial" Accept-Language header. This makes the challenge construction inconsistent.

This commit fixes this issue by only considering up to the first five characters of the Accept-Language header when making a challenge string.

<!--
delete me and describe your change here, give enough context for a maintainer to understand what and why

See https://anubis.techaro.lol/docs/developer/code-quality for more information
-->

Checklist:

- [x] Added a description of the changes to the `[Unreleased]` section of docs/docs/CHANGELOG.md
- [ ] Added test cases to [the relevant parts of the codebase](https://anubis.techaro.lol/docs/developer/code-quality)
- [ ] Ran integration tests `npm run test:integration` (unsupported on Windows, please use WSL)
