### PR TITLE
refactor(api): Clean up production endpoints

### DIFF
--- a/docs/docs/CHANGELOG.md
+++ b/docs/docs/CHANGELOG.md
@@ -10,10 +10,13 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
+- Remove the unused `/test-error` endpoint and update the testing endpoint `/make-challenge` to only be enabled in 
+  development 
+
 
 ## v1.19.1: Jenomis cen Lexentale - Echo 1
 
-Return `data/bots/ai-robots-txt.yaml` to avoid breaking configs [#599](https://github.com/TecharoHQ/anubis/issues/599)
+- Return `data/bots/ai-robots-txt.yaml` to avoid breaking configs [#599](https://github.com/TecharoHQ/anubis/issues/599)
 
 ## v1.19.0: Jenomis cen Lexentale
 
@@ -28,27 +31,27 @@ Mostly a bunch of small features, no big ticket things this time.
 - Add `--target-insecure-skip-verify` flag/envvar to allow Anubis to hit a self-signed HTTPS backend
 - Minor adjustments to FreeBSD rc.d script to allow for more flexible configuration.
 - Added Podman and Docker support for running Playwright tests
-- Add a default rule to throw challenges when a request with the `X-Firefox-Ai` header is set.
+- Add a default rule to throw challenges when a request with the `X-Firefox-Ai` header is set
 - Updated the nonce value in the challenge JWT cookie to be a string instead of a number
 - Rename cookies in response to user feedback
 - Ensure cookie renaming is consistent across configuration options
 - Add Bookstack app in data
 - Truncate everything but the first five characters of Accept-Language headers when making challenges
 - Ensure client JavaScript is served with Content-Type text/javascript.
-- Add `--target-host` flag/envvar to allow changing the value of the Host header in requests forwarded to the target service.
+- Add `--target-host` flag/envvar to allow changing the value of the Host header in requests forwarded to the target service
 - Bump AI-robots.txt to version 1.31
 - Add `RuntimeDirectory` to systemd unit settings so native packages can listen over unix sockets
 - Added SearXNG instance tracker whitelist policy
 - Added Qualys SSL Labs whitelist policy
 - Fixed cookie deletion logic ([#520](https://github.com/TecharoHQ/anubis/issues/520), [#522](https://github.com/TecharoHQ/anubis/pull/522))
-- Add `--target-sni` flag/envvar to allow changing the value of the TLS handshake hostname in requests forwarded to the target service.
+- Add `--target-sni` flag/envvar to allow changing the value of the TLS handshake hostname in requests forwarded to the target service
 - Fixed CEL expression matching validator to now properly error out when it receives empty expressions
-- Added OpenRC init.d script.
-- Added `--version` flag.
-- Added `anubis_proxied_requests_total` metric to count proxied requests.
+- Added OpenRC init.d script
+- Added `--version` flag
+- Added `anubis_proxied_requests_total` metric to count proxied requests
 - Add `Applebot` as "good" web crawler
-- Reorganize AI/LLM crawler blocking into three separate stances, maintaining existing status quo as default.
-- Split out AI/LLM user agent blocking policies, adding documentation for each.
+- Reorganize AI/LLM crawler blocking into three separate stances, maintaining existing status quo as default
+- Split out AI/LLM user agent blocking policies, adding documentation for each
 
 ## v1.18.0: Varis zos Galvus
 

--- a/lib/anubis.go
+++ b/lib/anubis.go
@@ -438,11 +438,6 @@ func (s *Server) PassChallenge(w http.ResponseWriter, r *http.Request) {
 	http.Redirect(w, r, redir, http.StatusFound)
 }
 
-func (s *Server) TestError(w http.ResponseWriter, r *http.Request) {
-	err := r.FormValue("err")
-	s.respondWithError(w, r, err)
-}
-
 func cr(name string, rule config.Rule) policy.CheckResult {
 	return policy.CheckResult{
 		Name: name,

--- a/lib/config.go
+++ b/lib/config.go
@@ -132,12 +132,15 @@ func New(opts Options) (*Server, error) {
 		}), "GET")
 	}
 
-	registerWithPrefix(anubis.APIPrefix+"make-challenge", http.HandlerFunc(result.MakeChallenge), "POST")
 	registerWithPrefix(anubis.APIPrefix+"pass-challenge", http.HandlerFunc(result.PassChallenge), "GET")
 	registerWithPrefix(anubis.APIPrefix+"check", http.HandlerFunc(result.maybeReverseProxyHttpStatusOnly), "")
-	registerWithPrefix(anubis.APIPrefix+"test-error", http.HandlerFunc(result.TestError), "GET")
 	registerWithPrefix("/", http.HandlerFunc(result.maybeReverseProxyOrPage), "")
 
+	//goland:noinspection GoBoolExpressions
+	if anubis.Version == "devel" {
+		// make-challenge is only used in tests. Only enable while version is devel
+		registerWithPrefix(anubis.APIPrefix+"make-challenge", http.HandlerFunc(result.MakeChallenge), "POST")
+	}
 	result.mux = mux
 
 	return result, nil


### PR DESCRIPTION
Closes #605 
Also removes the /test-error endpoint as it appears to be unused 

Checklist:

- [x] Added a description of the changes to the `[Unreleased]` section of docs/docs/CHANGELOG.md
- [ ] Added test cases to [the relevant parts of the codebase](https://anubis.techaro.lol/docs/developer/code-quality)
- [ ] Ran integration tests `npm run test:integration` (unsupported on Windows, please use WSL)
