### PR TITLE
docs(subrequest-auth): document required policy changes

### DIFF
--- a/.github/actions/spelling/expect.txt
+++ b/.github/actions/spelling/expect.txt
@@ -9,6 +9,7 @@ anubistest
 Applebot
 archlinux
 badregexes
+bdba
 berr
 bingbot
 bitcoin
@@ -27,6 +28,7 @@ caninetools
 Cardyb
 celchecker
 CELPHASE
+cerr
 certresolver
 CGNAT
 cgr
@@ -183,6 +185,7 @@ prebaked
 privkey
 promauto
 promhttp
+proofofwork
 pwcmd
 pwuser
 qualys

--- a/docs/docs/admin/configuration/subrequest-auth.mdx
+++ b/docs/docs/admin/configuration/subrequest-auth.mdx
@@ -10,6 +10,20 @@ Anubis can act in one of two modes:
 1. Reverse proxy (the default): Anubis sits in the middle of all traffic and then will reverse proxy it to its destination. This is the moral equivalent of a middleware in your favorite web framework.
 2. Subrequest authentication mode: Anubis listens for requests and if they don't pass muster then they are forwarded to Anubis for challenge processing. This is the equivalent of Anubis being a sidecar service.
 
+:::note
+
+Subrequest authentication requires changing the default policy because nginx interprets the default `DENY` status code `200` as successful authentication and allows the request.
+
+```yaml
+status_codes:
+  CHALLENGE: 200
+  DENY: 403
+```
+
+[See policy definitions](../policies.mdx).
+
+:::
+
 ## Nginx
 
 Anubis can perform [subrequest authentication](https://docs.nginx.com/nginx/admin-guide/security-controls/configuring-subrequest-authentication/) with the `auth_request` module in Nginx. In order to set this up, keep the following things in mind:


### PR DESCRIPTION
Even if totally logical, it caught me by surprise that the subrequest auth configuration by default allows all denied requests.

Checklist:

- [ ] Added a description of the changes to the `[Unreleased]` section of docs/docs/CHANGELOG.md
- [ ] Added test cases to [the relevant parts of the codebase](https://anubis.techaro.lol/docs/developer/code-quality)
- [ ] Ran integration tests `npm run test:integration` (unsupported on Windows, please use WSL)
