### PR TITLE
feat(lib): implement request weight

### DIFF
--- a/docs/docs/CHANGELOG.md
+++ b/docs/docs/CHANGELOG.md
@@ -11,6 +11,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+- Requests can have their weight be adjusted, if a request weighs zero then it is allowed through
 - Refactor challenge presentation logic to use a challenge registry
 - Allow challenge implementations to register HTTP routes
 

--- a/lib/anubis.go
+++ b/lib/anubis.go
@@ -406,10 +406,11 @@ func (s *Server) TestError(w http.ResponseWriter, r *http.Request) {
 	s.respondWithError(w, r, err)
 }
 
-func cr(name string, rule config.Rule) policy.CheckResult {
+func cr(name string, rule config.Rule, weight int) policy.CheckResult {
 	return policy.CheckResult{
-		Name: name,
-		Rule: rule,
+		Name:   name,
+		Rule:   rule,
+		Weight: weight,
 	}
 }
 
@@ -425,6 +426,8 @@ func (s *Server) check(r *http.Request) (policy.CheckResult, *policy.Bot, error)
 		return decaymap.Zilch[policy.CheckResult](), nil, fmt.Errorf("[misconfiguration] %q is not an IP address", host)
 	}
 
+	weight := 0
+
 	for _, b := range s.policy.Bots {
 		match, err := b.Rules.Check(r)
 		if err != nil {
@@ -432,11 +435,28 @@ func (s *Server) check(r *http.Request) (policy.CheckResult, *policy.Bot, error)
 		}
 
 		if match {
-			return cr("bot/"+b.Name, b.Action), &b, nil
+			switch b.Action {
+			case config.RuleDeny, config.RuleAllow, config.RuleBenchmark:
+				return cr("bot/"+b.Name, b.Action, weight), &b, nil
+			case config.RuleChallenge:
+				weight += 5
+			case config.RuleWeigh:
+				weight += b.Weight.Adjust
+			}
+		}
+
+		if weight < 0 {
+			return cr("weight/okay", config.RuleAllow, weight), &policy.Bot{
+				Challenge: &config.ChallengeRules{
+					Difficulty: s.policy.DefaultDifficulty,
+					ReportAs:   s.policy.DefaultDifficulty,
+					Algorithm:  config.DefaultAlgorithm,
+				},
+			}, nil
 		}
 	}
 
-	return cr("default/allow", config.RuleAllow), &policy.Bot{
+	return cr("default/allow", config.RuleAllow, weight), &policy.Bot{
 		Challenge: &config.ChallengeRules{
 			Difficulty: s.policy.DefaultDifficulty,
 			ReportAs:   s.policy.DefaultDifficulty,

--- a/lib/policy/bot.go
+++ b/lib/policy/bot.go
@@ -12,6 +12,7 @@ type Bot struct {
 	Challenge *config.ChallengeRules
 	Name      string
 	Action    config.Rule
+	Weight    *config.Weight
 }
 
 func (b Bot) Hash() string {

--- a/lib/policy/checkresult.go
+++ b/lib/policy/checkresult.go
@@ -7,12 +7,15 @@ import (
 )
 
 type CheckResult struct {
-	Name string
-	Rule config.Rule
+	Name   string
+	Rule   config.Rule
+	Weight int
 }
 
 func (cr CheckResult) LogValue() slog.Value {
 	return slog.GroupValue(
 		slog.String("name", cr.Name),
-		slog.String("rule", string(cr.Rule)))
+		slog.String("rule", string(cr.Rule)),
+		slog.Int("weight", cr.Weight),
+	)
 }

--- a/lib/policy/config/config.go
+++ b/lib/policy/config/config.go
@@ -39,20 +39,22 @@ const (
 	RuleAllow     Rule = "ALLOW"
 	RuleDeny      Rule = "DENY"
 	RuleChallenge Rule = "CHALLENGE"
+	RuleWeigh     Rule = "WEIGH"
 	RuleBenchmark Rule = "DEBUG_BENCHMARK"
 )
 
 const DefaultAlgorithm = "fast"
 
 type BotConfig struct {
-	UserAgentRegex *string           `json:"user_agent_regex"`
-	PathRegex      *string           `json:"path_regex"`
-	HeadersRegex   map[string]string `json:"headers_regex"`
-	Expression     *ExpressionOrList `json:"expression"`
+	UserAgentRegex *string           `json:"user_agent_regex,omitempty"`
+	PathRegex      *string           `json:"path_regex,omitempty"`
+	HeadersRegex   map[string]string `json:"headers_regex,omitempty"`
+	Expression     *ExpressionOrList `json:"expression,omitempty"`
 	Challenge      *ChallengeRules   `json:"challenge,omitempty"`
+	Weight         *Weight           `json:"weight,omitempty"`
 	Name           string            `json:"name"`
 	Action         Rule              `json:"action"`
-	RemoteAddr     []string          `json:"remote_addresses"`
+	RemoteAddr     []string          `json:"remote_addresses,omitempty"`
 }
 
 func (b BotConfig) Zero() bool {
@@ -144,7 +146,7 @@ func (b BotConfig) Valid() error {
 	}
 
 	switch b.Action {
-	case RuleAllow, RuleBenchmark, RuleChallenge, RuleDeny:
+	case RuleAllow, RuleBenchmark, RuleChallenge, RuleDeny, RuleWeigh:
 		// okay
 	default:
 		errs = append(errs, fmt.Errorf("%w: %q", ErrUnknownAction, b.Action))
@@ -154,6 +156,10 @@ func (b BotConfig) Valid() error {
 		if err := b.Challenge.Valid(); err != nil {
 			errs = append(errs, err)
 		}
+	}
+
+	if b.Action == RuleWeigh && b.Weight == nil {
+		b.Weight = &Weight{Adjust: 5}
 	}
 
 	if len(errs) != 0 {

--- a/lib/policy/config/config_test.go
+++ b/lib/policy/config/config_test.go
@@ -168,6 +168,25 @@ func TestBotValid(t *testing.T) {
 			},
 			err: nil,
 		},
+		{
+			name: "weight rule without weight",
+			bot: BotConfig{
+				Name:           "weight-adjust-if-mozilla",
+				Action:         RuleWeigh,
+				UserAgentRegex: p("Mozilla"),
+			},
+		},
+		{
+			name: "weight rule with weight adjust",
+			bot: BotConfig{
+				Name:           "weight-adjust-if-mozilla",
+				Action:         RuleWeigh,
+				UserAgentRegex: p("Mozilla"),
+				Weight: &Weight{
+					Adjust: 5,
+				},
+			},
+		},
 	}
 
 	for _, cs := range tests {

--- a/lib/policy/config/expressionorlist.go
+++ b/lib/policy/config/expressionorlist.go
@@ -14,8 +14,8 @@ var (
 
 type ExpressionOrList struct {
 	Expression string   `json:"-"`
-	All        []string `json:"all"`
-	Any        []string `json:"any"`
+	All        []string `json:"all,omitempty"`
+	Any        []string `json:"any,omitempty"`
 }
 
 func (eol ExpressionOrList) Equal(rhs *ExpressionOrList) bool {

--- a/lib/policy/config/testdata/good/simple-weight.yaml
+++ b/lib/policy/config/testdata/good/simple-weight.yaml
@@ -1,0 +1,6 @@
+bots:
+  - name: simple-weight-adjust
+    action: WEIGH
+    user_agent_regex: Mozilla
+    weight:
+      adjust: 5

--- a/lib/policy/config/testdata/good/weight-no-weight.yaml
+++ b/lib/policy/config/testdata/good/weight-no-weight.yaml
@@ -1,0 +1,4 @@
+bots:
+  - name: weight
+    action: WEIGH
+    user_agent_regex: Mozilla

--- a/lib/policy/config/weight.go
+++ b/lib/policy/config/weight.go
@@ -1,0 +1,5 @@
+package config
+
+type Weight struct {
+	Adjust int `json:"adjust"`
+}

--- a/lib/policy/policy.go
+++ b/lib/policy/policy.go
@@ -117,6 +117,10 @@ func ParseConfig(fin io.Reader, fname string, defaultDifficulty int) (*ParsedCon
 			}
 		}
 
+		if b.Weight != nil {
+			parsedBot.Weight = b.Weight
+		}
+
 		parsedBot.Rules = cl
 
 		result.Bots = append(result.Bots, parsedBot)


### PR DESCRIPTION
Replaces #608

This is a big one and will be what makes Anubis a generic web application firewall. This introduces the WEIGH option, allowing administrators to have facets of request metadata add or remove "weight", or the level of suspicion. This really makes Anubis weigh the soul of requests.

<!--
delete me and describe your change here, give enough context for a maintainer to understand what and why

See https://anubis.techaro.lol/docs/developer/code-quality for more information
-->

Checklist:

- [ ] Request weight documentation
- [ ] Adapt some existing rules to use request weight
- [x] Added a description of the changes to the `[Unreleased]` section of docs/docs/CHANGELOG.md
- [ ] Added test cases to [the relevant parts of the codebase](https://anubis.techaro.lol/docs/developer/code-quality)
- [ ] Ran integration tests `npm run test:integration` (unsupported on Windows, please use WSL)
