### PR TITLE
docs(known-instances): add wiki.dolphin-emu.org to known instances

### DIFF
--- a/docs/docs/user/known-instances.md
+++ b/docs/docs/user/known-instances.md
@@ -40,6 +40,7 @@ This page contains a non-exhaustive list with all websites using Anubis.
 - https://openwrt.org/
 - https://minihoot.site
 - https://catgirl.click/
+- https://wiki.dolphin-emu.org/
 - <details>
   <summary>FreeCAD</summary>
   - https://forum.freecad.org/


### PR DESCRIPTION
The Dolphin emulation project added Anubis to their wiki, see https://dolphin-emu.org/blog/2025/06/04/dolphin-progress-report-release-2506/?cr=de#dolphin-vs-aggressive-ai-scraper-bots

Checklist:

- [ ] Added a description of the changes to the `[Unreleased]` section of docs/docs/CHANGELOG.md
- [ ] Added test cases to [the relevant parts of the codebase](https://anubis.techaro.lol/docs/developer/code-quality)
- [ ] Ran integration tests `npm run test:integration` (unsupported on Windows, please use WSL)
