### PR TITLE
docs(admin/environments): Prefer IPv6 over IPv4 for apache2 listener directive

### DIFF
--- a/docs/docs/admin/environments/apache.mdx
+++ b/docs/docs/admin/environments/apache.mdx
@@ -120,6 +120,14 @@ Make sure to add a separate configuration file for the listener on port 3001:
 ```text
 # /etc/httpd/conf.d/listener-3001.conf
 
+Listen [::1]:3001
+```
+
+In case you are running an IPv4-only system, use the following configuration instead:
+
+```text
+# /etc/httpd/conf.d/listener-3001.conf
+
 Listen 127.0.0.1:3001
 ```
 


### PR DESCRIPTION
Update apache2 documentation to prefer IPv6 over IPv4 for the apache2 listener directive on dual-stack or IPv6-enabled systems. I'd only recommend using v4 on systems that have no support for v6 yet because I think this way it is more consistent, and let's be honest, IPv6 should be the preferred way to do things in this day and age.

Checklist:

- [ ] Added a description of the changes to the `[Unreleased]` section of docs/docs/CHANGELOG.md
- [ ] Added test cases to [the relevant parts of the codebase](https://anubis.techaro.lol/docs/developer/code-quality)
- [ ] Ran integration tests `npm run test:integration` (unsupported on Windows, please use WSL)
