### PR TITLE
test(ssh-ci): re-enable GOARCH=ppc64le

### DIFF
--- a/.github/workflows/ssh-ci.yml
+++ b/.github/workflows/ssh-ci.yml
@@ -16,7 +16,7 @@ jobs:
       matrix:
         host:
           - ubuntu@riscv64.techaro.lol
-          #- ci@ppc64le.techaro.lol # XXX(Xe 2025-06-11 16:58): This seems to be broken for now, emailed Taptor CS for advice
+          - ci@ppc64le.techaro.lol
     steps:
       - name: Checkout code
         uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2


### PR DESCRIPTION
This reverts commit 5e95da6b6c820bd12b96e06c732dc9000dbaa81e.

BLOCKED until ppc64le.techaro.lol responds over SSH.
