### PR TITLE
feat: docker buildx bake support

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,0 +1,25 @@
+.env
+*.deb
+*.rpm
+
+# Additional package locks
+pnpm-lock.yaml
+yarn.lock
+
+# Go binaries and test artifacts
+main
+*.test
+
+node_modules
+
+# MacOS
+.DS_store
+
+# Intellij
+.idea
+
+# how does this get here
+doc/VERSION
+
+web/static/js/*
+!web/static/js/.gitignore

--- a/Dockerfile
+++ b/Dockerfile
@@ -25,5 +25,6 @@ RUN apk -U add ca-certificates mailcap
 COPY --from=build /app/bin/anubis /app/bin/anubis
 
 CMD ["/app/bin/anubis"]
+HEALTHCHECK --interval=30s --timeout=30s --start-period=5s --retries=3 CMD [ "/app/bin/anubis", "--healthcheck" ]
 
 LABEL org.opencontainers.image.source="https://github.com/TecharoHQ/anubis"

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,29 @@
+ARG ALPINE_VERSION=edge
+FROM --platform=${BUILDPLATFORM} alpine:${ALPINE_VERSION} AS build
+
+ARG TARGETOS
+ARG TARGETARCH
+ARG COMPONENT=anubis
+ARG VERSION=devel-docker
+
+RUN apk -U add go nodejs git build-base git npm bash zstd brotli gzip
+
+WORKDIR /app
+
+COPY go.mod go.sum ./
+RUN go mod download
+
+COPY . .
+RUN --mount=type=cache,target=/root/.cache npm ci && npm run assets
+RUN --mount=type=cache,target=/root/.cache GOOS=${TARGETOS} GOARCH=${TARGETARCH} CGO_ENABLED=0 GOARM=7 go build -gcflags "all=-N -l" -o /app/bin/${COMPONENT} -ldflags "-s -w -extldflags -static -X github.com/TecharoHQ/anubis.Version=${VERSION}" ./cmd/${COMPONENT}
+
+FROM alpine:${ALPINE_VERSION} AS run
+WORKDIR /app
+
+RUN apk -U add ca-certificates mailcap
+
+COPY --from=build /app/bin/anubis /app/bin/anubis
+
+CMD ["/app/bin/anubis"]
+
+LABEL org.opencontainers.image.source="https://github.com/TecharoHQ/anubis"

--- a/docker-bake.hcl
+++ b/docker-bake.hcl
@@ -1,0 +1,27 @@
+variable "ALPINE_VERSION" { default = "3.22" }
+variable "GITHUB_SHA" { default = "devel" }
+
+group "default" {
+  targets = [
+    "anubis",
+  ]
+}
+
+target "anubis" {
+  args = {
+    ALPINE_VERSION = "3.22"
+  }
+  context = "."
+  dockerfile = "./Dockerfile"
+  platforms = [
+    "linux/amd64",
+    "linux/arm64",
+    "linux/arm/v7",
+    "linux/ppc64le",
+    "linux/riscv64",
+  ]
+  pull = true
+  tags = [
+    "ghcr.io/techarohq/anubis:${GITHUB_SHA}"
+  ]
+}


### PR DESCRIPTION
Add support for `docker buildx bake` to build Anubis images for many platforms at once.

- [ ] Replace cmd/containerbuild
- [ ] Amend CI logic to use docker buildx bake

- **feat: build with docker buildx bake**
- **fix(Dockerfile): add HEALTHCHECK**

<!--
delete me and describe your change here, give enough context for a maintainer to understand what and why

See https://anubis.techaro.lol/docs/developer/code-quality for more information
-->

Checklist:

- [ ] Added a description of the changes to the `[Unreleased]` section of docs/docs/CHANGELOG.md
- [ ] Added test cases to [the relevant parts of the codebase](https://anubis.techaro.lol/docs/developer/code-quality)
- [ ] Ran integration tests `npm run test:integration` (unsupported on Windows, please use WSL)
