### PR TITLE
Speed up playwright tests by 2x

### DIFF
--- a/.github/actions/spelling/expect.txt
+++ b/.github/actions/spelling/expect.txt
@@ -12,7 +12,6 @@ archlinux
 badregexes
 bdba
 berr
-betteralign
 bingbot
 bitcoin
 blogging
@@ -164,7 +163,6 @@ mojeekbot
 mozilla
 nbf
 netsurf
-NFlag
 nginx
 nobots
 NONINFRINGEMENT
@@ -213,6 +211,7 @@ runlevels
 RUnlock
 sas
 sasl
+screenshots
 Scumm
 searchbot
 searx

--- a/.github/workflows/go.yml
+++ b/.github/workflows/go.yml
@@ -80,6 +80,15 @@ jobs:
       run: |
         npm ci
 
+    - name: install playwright browsers
+      if: steps.playwright-cache.outputs.cache-hit != 'true'
+      run: |
+        npx --no-install playwright@1.52.0 install --with-deps
+
+    - name: start playwright server
+      run: |
+        npx --no-install playwright@1.52.0 run-server --port 9001 &
+
     - name: Build
       run: npm run build
 
@@ -90,15 +99,6 @@ jobs:
       uses: dominikh/staticcheck-action@fe1dd0c3658873b46f8c9bb3291096a617310ca6 # v1.3.1
       with:
         version: "latest"
-
-    - name: install playwright browsers
-      if: steps.playwright-cache.outputs.cache-hit != 'true'
-      run: |
-        npx --no-install playwright@1.52.0 install --with-deps
-
-    - name: start playwright server
-      run: |
-        npx --no-install playwright@1.52.0 run-server --port 9001 &
 
 
     - name: Govulncheck

--- a/.github/workflows/go.yml
+++ b/.github/workflows/go.yml
@@ -58,14 +58,21 @@ jobs:
         restore-keys: |
           ${{ runner.os }}-golang-
 
-    - name: Cache node modules
+    - name: Cache npm cache
       uses: actions/cache@5a3ec84eff668545956fd18022155c47e93e2684 # v4.2.3
       with:
         path: ~/.npm
-        key: ${{ runner.os }}-node-${{ hashFiles('**/package-lock.json') }}
+        key: ${{ runner.os }}-npm-cache-${{ hashFiles('**/package-lock.json') }}
         restore-keys: |
-          ${{ runner.os }}-node-
+          ${{ runner.os }}-npm-cache-
 
+    - name: Cache node_modules
+      uses: actions/cache@5a3ec84eff668545956fd18022155c47e93e2684 # v4.2.3
+      with:
+        path: node_modules
+        key: ${{ runner.os }}-node-modules-${{ hashFiles('**/package-lock.json') }}
+        restore-keys: |
+          ${{ runner.os }}-node-modules-
     - name: Cache playwright binaries
       uses: actions/cache@5a3ec84eff668545956fd18022155c47e93e2684 # v4.2.3
       id: playwright-cache

--- a/.github/workflows/go.yml
+++ b/.github/workflows/go.yml
@@ -58,22 +58,27 @@ jobs:
         restore-keys: |
           ${{ runner.os }}-golang-
 
+    - name: Cache node modules
+      uses: actions/cache@5a3ec84eff668545956fd18022155c47e93e2684 # v4.2.3
+      with:
+        path: ~/.npm
+        key: ${{ runner.os }}-node-${{ hashFiles('**/package-lock.json') }}
+        restore-keys: |
+          ${{ runner.os }}-node-
+
     - name: Cache playwright binaries
       uses: actions/cache@5a3ec84eff668545956fd18022155c47e93e2684 # v4.2.3
       id: playwright-cache
       with:
         path: |
           ~/.cache/ms-playwright
-        key: ${{ runner.os }}-playwright-${{ hashFiles('**/go.sum') }}
+        key: ${{ runner.os }}-playwright-1.52.0
+        restore-keys: |
+          ${{ runner.os }}-playwright-
 
     - name: install node deps
       run: |
         npm ci
-
-    - name: install playwright browsers
-      run: |
-        npx --no-install playwright@1.52.0 install --with-deps
-        npx --no-install playwright@1.52.0 run-server --port 9001 &
 
     - name: Build
       run: npm run build
@@ -85,6 +90,16 @@ jobs:
       uses: dominikh/staticcheck-action@fe1dd0c3658873b46f8c9bb3291096a617310ca6 # v1.3.1
       with:
         version: "latest"
+
+    - name: install playwright browsers
+      if: steps.playwright-cache.outputs.cache-hit != 'true'
+      run: |
+        npx --no-install playwright@1.52.0 install --with-deps
+
+    - name: start playwright server
+      run: |
+        npx --no-install playwright@1.52.0 run-server --port 9001 &
+
 
     - name: Govulncheck
       run: |

--- a/internal/test/playwright_test.go
+++ b/internal/test/playwright_test.go
@@ -201,7 +201,7 @@ func startPlaywright(t *testing.T) {
 
 	for {
 		if _, err := http.Get(fmt.Sprintf("http://localhost:%d", *playwrightPort)); err != nil {
-			fmt.Println("Can't reach playwright server... trying again in 500ms")
+			t.Logf("Can't reach playwright server... trying again in 500ms")
 			time.Sleep(500 * time.Millisecond)
 			continue
 		}

--- a/internal/test/playwright_test.go
+++ b/internal/test/playwright_test.go
@@ -268,6 +268,8 @@ func TestPlaywrightBrowser(t *testing.T) {
 		})
 
 		for _, tc := range testCases {
+			typ := typ // Capture loop variable
+			tc := tc   // Capture loop variable
 			name := fmt.Sprintf("%s/%s", typ.Name(), tc.name)
 			t.Run(name, func(t *testing.T) {
 				t.Parallel()

--- a/internal/test/playwright_test.go
+++ b/internal/test/playwright_test.go
@@ -228,7 +228,7 @@ func TestPlaywrightBrowser(t *testing.T) {
 	pw := setupPlaywright(t)
 	anubisURL := spawnAnubis(t)
 
-	browsers := []playwright.BrowserType{pw.Chromium, pw.Firefox}
+	browsers := []playwright.BrowserType{pw.Chromium, pw.Firefox, pw.WebKit}
 
 	for _, typ := range browsers {
 		typ := typ // Bind the current value of the loop variable

--- a/internal/test/playwright_test.go
+++ b/internal/test/playwright_test.go
@@ -231,6 +231,7 @@ func TestPlaywrightBrowser(t *testing.T) {
 	browsers := []playwright.BrowserType{pw.Chromium, pw.Firefox}
 
 	for _, typ := range browsers {
+		typ := typ // Bind the current value of the loop variable
 		t.Run(typ.Name()+"/warmup", func(t *testing.T) {
 			t.Parallel()
 			t.Logf("Starting warmup for %s", typ.Name())


### PR DESCRIPTION
Sped up the playwright tests from 115s > 53.499s > 49.9s  speeding up the overall tests by around 50s (CI is annoying lol)

Checklist:

- [ ] Added a description of the changes to the `[Unreleased]` section of docs/docs/CHANGELOG.md
- [ ] Added test cases to [the relevant parts of the codebase](https://anubis.techaro.lol/docs/developer/code-quality)
- [x] Ran integration tests `npm run test:integration` (unsupported on Windows, please use WSL)
