### PR TITLE
fix(geo): correct typo "counties" to "countries"

### DIFF
--- a/data/botPolicies.yaml
+++ b/data/botPolicies.yaml
@@ -56,7 +56,7 @@ bots:
   - name: countries-with-aggressive-scrapers
     action: WEIGH
     geoip:
-      counties:
+      countries:
         - BR
         - CN
     weight:

--- a/docs/docs/admin/thoth.mdx
+++ b/docs/docs/admin/thoth.mdx
@@ -59,7 +59,7 @@ For example, to add 10 weight points to requests from Brazil and China:
 - name: countries-with-aggressive-scrapers
   action: WEIGH
   geoip:
-    counties:
+    countries:
       - BR
       - CN
   weight:


### PR DESCRIPTION
There was a typo in example YAML files

Checklist:

- [x] Added a description of the changes to the `[Unreleased]` section of docs/docs/CHANGELOG.md
- [ ] Added test cases to [the relevant parts of the codebase](https://anubis.techaro.lol/docs/developer/code-quality)
- [ ] Ran integration tests `npm run test:integration` (unsupported on Windows, please use WSL)
