### PR TITLE
docs(known-instances): add wiki.koha-community.org

### DIFF
--- a/docs/docs/user/known-instances.md
+++ b/docs/docs/user/known-instances.md
@@ -43,6 +43,7 @@ This page contains a non-exhaustive list with all websites using Anubis.
 - https://wiki.dolphin-emu.org/
 - https://squirreljme.cc/
 - https://gitlab.postmarketos.org/
+- https://wiki.koha-community.org/
 - <details>
   <summary>FreeCAD</summary>
   - https://forum.freecad.org/


### PR DESCRIPTION
Found on the Internet, the wiki of Koha (an integrated library system) is using Anubis ^^

Checklist:

- [ ] Added a description of the changes to the `[Unreleased]` section of docs/docs/CHANGELOG.md
- [ ] Added test cases to [the relevant parts of the codebase](https://anubis.techaro.lol/docs/developer/code-quality)
- [ ] Ran integration tests `npm run test:integration` (unsupported on Windows, please use WSL)
