### PR TITLE
remove incorrect module mentions

### DIFF
--- a/docs/docs/admin/environments/apache.mdx
+++ b/docs/docs/admin/environments/apache.mdx
@@ -34,27 +34,6 @@ These examples assume that you are using a setup where your nginx configuration 
 
 :::
 
-## Dependencies
-
-Install the following dependencies for proxying HTTP:
-
-<Tabs>
-  <TabItem value="rpm" label="Red Hat / RPM" default>
-
-```text
-dnf -y install mod_proxy_html
-```
-
-  </TabItem>
-  <TabItem value="deb" label="Debian / Ubuntu / apt">
-
-```text
-apt-get install -y libapache2-mod-proxy-html libxml2-dev
-```
-
-  </TabItem>
-</Tabs>
-
 ## Configuration
 
 Assuming you are protecting `anubistest.techaro.lol`, you need the following server configuration blocks:


### PR DESCRIPTION
mod_proxy_html is for modifying html content in response bodies. The example configs are using mod_proxy_http.

https://httpd.apache.org/docs/2.4/mod/mod_proxy_html.html vs
https://httpd.apache.org/docs/2.4/mod/mod_proxy_http.html

And anyway mod_proxy + mod_proxy_http should already be installed on almost all systems.

<!--
delete me and describe your change here, give enough context for a maintainer to understand what and why

See https://anubis.techaro.lol/docs/developer/code-quality for more information
-->

Checklist:

- [ ] Added a description of the changes to the `[Unreleased]` section of docs/docs/CHANGELOG.md
- [ ] Added test cases to [the relevant parts of the codebase](https://anubis.techaro.lol/docs/developer/code-quality)
- [ ] Ran integration tests `npm run test:integration` (unsupported on Windows, please use WSL)
