### PR TITLE
docs(known-instances): add extensions.typo3.org

### DIFF
--- a/docs/docs/user/known-instances.md
+++ b/docs/docs/user/known-instances.md
@@ -44,6 +44,7 @@ This page contains a non-exhaustive list with all websites using Anubis.
 - https://squirreljme.cc/
 - https://gitlab.postmarketos.org/
 - https://wiki.koha-community.org/
+- https://extensions.typo3.org/
 - <details>
   <summary>FreeCAD</summary>
   - https://forum.freecad.org/


### PR DESCRIPTION
New deployment spotted!

Anubis is currently active on https://extensions.typo3.org.

Checklist:

- [ ] Added a description of the changes to the `[Unreleased]` section of docs/docs/CHANGELOG.md
- [ ] Added test cases to [the relevant parts of the codebase](https://anubis.techaro.lol/docs/developer/code-quality)
- [ ] Ran integration tests `npm run test:integration` (unsupported on Windows, please use WSL)
