### PR TITLE
fix(lib): fix invalid response after success in Chrome

### DIFF
--- a/docs/docs/CHANGELOG.md
+++ b/docs/docs/CHANGELOG.md
@@ -25,6 +25,7 @@ The big ticket items are as follows:
 - Refactor challenge presentation logic to use a challenge registry
 - Allow challenge implementations to register HTTP routes
 - [Imprint/Impressum support](./admin/configuration/impressum.mdx) ([#362](https://github.com/TecharoHQ/anubis/issues/362))
+- Fix "invalid response" after "Success!" in Chromium ([#564](https://github.com/TecharoHQ/anubis/issues/564))
 
 A lot of performance improvements have been made:
 

--- a/lib/anubis.go
+++ b/lib/anubis.go
@@ -77,14 +77,8 @@ type Server struct {
 func (s *Server) challengeFor(r *http.Request, difficulty int) string {
 	fp := sha256.Sum256(s.pub[:])
 
-	acceptLanguage := r.Header.Get("Accept-Language")
-	if len(acceptLanguage) > 5 {
-		acceptLanguage = acceptLanguage[:5]
-	}
-
 	challengeData := fmt.Sprintf(
-		"Accept-Language=%s,X-Real-IP=%s,User-Agent=%s,WeekTime=%s,Fingerprint=%x,Difficulty=%d",
-		acceptLanguage,
+		"X-Real-IP=%s,User-Agent=%s,WeekTime=%s,Fingerprint=%x,Difficulty=%d",
 		r.Header.Get("X-Real-Ip"),
 		r.UserAgent(),
 		time.Now().UTC().Round(24*7*time.Hour).Format(time.RFC3339),


### PR DESCRIPTION
Closes #564

This one is really dumb. Take a seat and listen to my tale of woe.

While @victorvalenca was working on #693 we ran into a strange issue. The tests would consistently pass on Firefox but instantly failed on Chrome. After adding increasingly desperate debugging logs to the mix, we found out that somehow Chrome was randomizing the contents of its Accept-Language header. This was making the challenge string get calculated differently, thus making things spuriously fail. I cannot figure out what causes Chrome to do this other than you being in an environment where you have more than one "system language" set.

Either way, this should finally fix this issue and bring peace to the land forever*.

<!--
delete me and describe your change here, give enough context for a maintainer to understand what and why

See https://anubis.techaro.lol/docs/developer/code-quality for more information
-->

Checklist:

- [x] Added a description of the changes to the `[Unreleased]` section of docs/docs/CHANGELOG.md
- [ ] Added test cases to [the relevant parts of the codebase](https://anubis.techaro.lol/docs/developer/code-quality)
- [x] Ran integration tests `npm run test:integration` (unsupported on Windows, please use WSL)
