### PR TITLE
Populate OpenGraph configurations to `Options.OpenGraph`

### DIFF
--- a/cmd/anubis/main.go
+++ b/cmd/anubis/main.go
@@ -353,6 +353,7 @@ func main() {
 		RedirectDomains:   redirectDomainsList,
 		Target:            *target,
 		WebmasterEmail:    *webmasterEmail,
+		OpenGraph:         policy.OpenGraph,
 	})
 	if err != nil {
 		log.Fatalf("can't construct libanubis.Server: %v", err)

--- a/docs/docs/CHANGELOG.md
+++ b/docs/docs/CHANGELOG.md
@@ -11,6 +11,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+- Fix OpenGraph passthrough ([#717](https://github.com/TecharoHQ/anubis/issues/717))
+
 ## v1.20.0: Thancred Waters
 
 The big ticket items are as follows:


### PR DESCRIPTION
I see #694 adds both [`Policy.OpenGraph`](https://github.com/TecharoHQ/anubis/pull/694/files#diff-9f6114d273eaabaa7d0da817daa547c05a8209f304129758808b1361c48b1aa9R388) and [`Options.OpenGraph`](https://github.com/TecharoHQ/anubis/pull/694/files#diff-723d6cb1b48895db61a43b5536bffca5ea1157d674fa1ac3903fc3f03addc31cR41). While the configuration is populated in `Policy.OpenGraph`, [it's still `Options.OpenGraph`](https://github.com/TecharoHQ/anubis/pull/694/files#diff-d5149d03328bfe7145aa99f4274ffb678ca26b66293bdcd1342481b5f209246fR83) that is read, which is unfortunately not populated.

Note:
* Maintainers may need to decide whether to use `Policy.OpenGraph` or `Options.OpenGraph`, but I received a report saying my anubis-fronted site lost OpenGraph passthrough, so here is a quick fix for whoever is concerned.
* For the reason state above, I do not expect this PR to be merged as I guess maintainers want to gradually switch to `Policy.OpenGraph`?
* BTW I reverted to anubis v1.18.0 on my website, which does not have this regression.

Checklist:

- [x] Added a description of the changes to the `[Unreleased]` section of docs/docs/CHANGELOG.md
- [ ] Added test cases to [the relevant parts of the codebase](https://anubis.techaro.lol/docs/developer/code-quality)
- [ ] Ran integration tests `npm run test:integration` (unsupported on Windows, please use WSL)
