### PR TITLE
fix(web/main): remove the success interstitial

### DIFF
--- a/docs/docs/CHANGELOG.md
+++ b/docs/docs/CHANGELOG.md
@@ -14,8 +14,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Determine the `BIND_NETWORK`/`--bind-network` value from the bind address ([#677](https://github.com/TecharoHQ/anubis/issues/677)).
 - Implement localization system. Find locale files in lib/localization/locales/.
 - Implement a [development container](https://containers.dev/) manifest to make contributions easier.
-- Fix dynamic cookie domains functionality ([#731](https://github.com/TecharoHQ/anubis/pull/731))
-- Add option for custom cookie prefix ([#732](https://github.com/TecharoHQ/anubis/pull/732))
+- Fix dynamic cookie domains functionality ([#731](https://github.com/TecharoHQ/anubis/pull/731)).
+- Add option for custom cookie prefix ([#732](https://github.com/TecharoHQ/anubis/pull/732)).
+- Remove the "Success" interstitial after a proof of work challenge is concluded.
 
 ## v1.20.0: Thancred Waters
 

--- a/web/js/main.mjs
+++ b/web/js/main.mjs
@@ -212,11 +212,6 @@ const t = (key) => translations[`js_${key}`] || translations[key] || key;
     const t1 = Date.now();
     console.log({ hash, nonce });
 
-    title.innerHTML = t('success');
-    status.innerHTML = `${t('done_took')} ${t1 - t0}ms, ${nonce} ${t('iterations')}`;
-    image.src = imageURL("happy", anubisVersion, basePrefix);
-    progress.style.display = "none";
-
     if (userReadDetails) {
       const container = document.getElementById("progress");
 
@@ -251,17 +246,15 @@ const t = (key) => translations[`js_${key}`] || translations[key] || key;
       container.onclick = onDetailsExpand;
       setTimeout(onDetailsExpand, 30000);
     } else {
-      setTimeout(() => {
-        const redir = window.location.href;
-        window.location.replace(
-          u(`${basePrefix}/.within.website/x/cmd/anubis/api/pass-challenge`, {
-            response: hash,
-            nonce,
-            redir,
-            elapsedTime: t1 - t0,
-          }),
-        );
-      }, 250);
+      const redir = window.location.href;
+      window.location.replace(
+        u(`${basePrefix}/.within.website/x/cmd/anubis/api/pass-challenge`, {
+          response: hash,
+          nonce,
+          redir,
+          elapsedTime: t1 - t0,
+        }),
+      );
     }
   } catch (err) {
     ohNoes({


### PR DESCRIPTION
I'm gonna be totally honest here, I'm still not sure why #564 is still an issue. This is really confusing and I'm going to totally throw out how Anubis issues challenges and redo it with Valkey (#201, #622).

The problem seems to be that I assume that the makeChallenge function in package lib is idempotent for the same client. I have no idea why this would be inconsistent, but for some reason it is and I'm just at a loss for words as to why this is happening.

This stops the bleeding by improving the UX as a stopgap.

<!--
delete me and describe your change here, give enough context for a maintainer to understand what and why

See https://anubis.techaro.lol/docs/developer/code-quality for more information
-->

Checklist:

- [x] Added a description of the changes to the `[Unreleased]` section of docs/docs/CHANGELOG.md
- [ ] Added test cases to [the relevant parts of the codebase](https://anubis.techaro.lol/docs/developer/code-quality)
- [x] Ran integration tests `npm run test:integration` (unsupported on Windows, please use WSL)
