### PR TITLE
docs(known-instances): add ebird.org

### DIFF
--- a/docs/docs/user/known-instances.md
+++ b/docs/docs/user/known-instances.md
@@ -45,6 +45,7 @@ This page contains a non-exhaustive list with all websites using Anubis.
 - https://gitlab.postmarketos.org/
 - https://wiki.koha-community.org/
 - https://extensions.typo3.org/
+- https://ebird.org/
 - <details>
   <summary>FreeCAD</summary>
   - https://forum.freecad.org/


### PR DESCRIPTION
Add eBird to instance list

eBird has been using Anubis for a few weeks now, so it should be added to the list.

Checklist:

- [ ] Added a description of the changes to the `[Unreleased]` section of docs/docs/CHANGELOG.md
- [ ] Added test cases to [the relevant parts of the codebase](https://anubis.techaro.lol/docs/developer/code-quality)
- [ ] Ran integration tests `npm run test:integration` (unsupported on Windows, please use WSL)
