### PR TITLE
fix(internal/thoth): don't block Anubis starting if healthcheck fails

### DIFF
--- a/docs/docs/CHANGELOG.md
+++ b/docs/docs/CHANGELOG.md
@@ -42,7 +42,7 @@ Anubis now supports localized responses. Locales can be added in [lib/localizati
 - [Brazilian Portugese](https://github.com/TecharoHQ/anubis/pull/726)
 - [Chinese (Traditional)](https://github.com/TecharoHQ/anubis/pull/759)
 - English
-- [Estonian](https://github.com/TecharoHQ/anubis/pull/783) 
+- [Estonian](https://github.com/TecharoHQ/anubis/pull/783)
 - [French](https://github.com/TecharoHQ/anubis/pull/716)
 - [German](https://github.com/TecharoHQ/anubis/pull/741)
 - [Spanish](https://github.com/TecharoHQ/anubis/pull/716)
@@ -99,6 +99,7 @@ There are a bunch of other assorted features and fixes too:
 - Make the [Open Graph](./admin/configuration/open-graph.mdx) subsystem and DNSBL subsystem use [storage backends](./admin/policies.mdx#storage-backends) instead of storing everything in memory by default.
 - Allow [Common Crawl](https://commoncrawl.org/) by default so scrapers have less incentive to scrape
 - The [bbolt storage backend](./admin/policies.mdx#bbolt) now runs its cleanup every hour instead of every five minutes.
+- Don't block Anubis starting up if [Thoth](./admin/thoth.mdx) health checks fail.
 
 ### Potentially breaking changes
 

--- a/internal/thoth/thoth.go
+++ b/internal/thoth/thoth.go
@@ -60,15 +60,6 @@ func New(ctx context.Context, thothURL, apiToken string, plaintext bool) (*Clien
 
 	hc := healthv1.NewHealthClient(conn)
 
-	resp, err := hc.Check(ctx, &healthv1.HealthCheckRequest{})
-	if err != nil {
-		return nil, fmt.Errorf("can't verify thoth health at %s: %w", thothURL, err)
-	}
-
-	if resp.Status != healthv1.HealthCheckResponse_SERVING {
-		return nil, fmt.Errorf("thoth is not healthy, wanted %s but got %s", healthv1.HealthCheckResponse_SERVING, resp.Status)
-	}
-
 	return &Client{
 		conn:    conn,
 		health:  hc,


### PR DESCRIPTION
Ref TI-20250709-0001

Checklist:

- [x] Added a description of the changes to the `[Unreleased]` section of docs/docs/CHANGELOG.md
- [ ] Added test cases to [the relevant parts of the codebase](https://anubis.techaro.lol/docs/developer/code-quality)
- [ ] Ran integration tests `npm run test:integration` (unsupported on Windows, please use WSL)
