### PR TITLE
fix: enable double slashes for optional path variables

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -97,6 +97,7 @@ require (
 	github.com/goreleaser/chglog v0.7.0 // indirect
 	github.com/goreleaser/fileglob v1.3.0 // indirect
 	github.com/goreleaser/nfpm/v2 v2.42.1 // indirect
+	github.com/gorilla/mux v1.8.1 // indirect
 	github.com/hashicorp/go-version v1.7.0 // indirect
 	github.com/huandu/xstrings v1.5.0 // indirect
 	github.com/jbenet/go-context v0.0.0-20150711004518-d14ea06fba99 // indirect

--- a/go.sum
+++ b/go.sum
@@ -212,6 +212,8 @@ github.com/goreleaser/fileglob v1.3.0 h1:/X6J7U8lbDpQtBvGcwwPS6OpzkNVlVEsFUVRx9+
 github.com/goreleaser/fileglob v1.3.0/go.mod h1:Jx6BoXv3mbYkEzwm9THo7xbr5egkAraxkGorbJb4RxU=
 github.com/goreleaser/nfpm/v2 v2.42.1 h1:xu2pLRgQuz2ab+YZFoeIzwU/M5jjjCKDGwv1lRbVGvk=
 github.com/goreleaser/nfpm/v2 v2.42.1/go.mod h1:dY53KWYKebkOocxgkmpM7SRX0Nv5hU+jEu2kIaM4/LI=
+github.com/gorilla/mux v1.8.1 h1:TuBL49tXwgrFYWhqrNgrUNEY92u81SPhu7sTdzQEiWY=
+github.com/gorilla/mux v1.8.1/go.mod h1:AKf9I4AEqPTmMytcMc0KkNouC66V3BtZ4qD5fmWSiMQ=
 github.com/grpc-ecosystem/go-grpc-middleware/providers/prometheus v1.1.0 h1:QGLs/O40yoNK9vmy4rhUGBVyMf1lISBGtXRpsu/Qu/o=
 github.com/grpc-ecosystem/go-grpc-middleware/providers/prometheus v1.1.0/go.mod h1:hM2alZsMUni80N33RBe6J0e423LB+odMj7d3EMP9l20=
 github.com/grpc-ecosystem/go-grpc-middleware/v2 v2.3.2 h1:sGm2vDRFUrQJO/Veii4h4zG2vvqG6uWNkBHSTqXOZk0=

--- a/lib/anubis.go
+++ b/lib/anubis.go
@@ -18,6 +18,7 @@ import (
 	"github.com/golang-jwt/jwt/v5"
 	"github.com/google/cel-go/common/types"
 	"github.com/google/uuid"
+	"github.com/gorilla/mux"
 
 	"github.com/prometheus/client_golang/prometheus"
 	"github.com/prometheus/client_golang/prometheus/promauto"
@@ -68,7 +69,7 @@ var (
 
 type Server struct {
 	next        http.Handler
-	mux         *http.ServeMux
+	mux         *mux.Router
 	policy      *policy.ParsedConfig
 	OGTags      *ogtags.OGTagCache
 	ed25519Priv ed25519.PrivateKey

--- a/lib/challenge/interface.go
+++ b/lib/challenge/interface.go
@@ -10,6 +10,7 @@ import (
 	"github.com/TecharoHQ/anubis/lib/policy/config"
 	"github.com/TecharoHQ/anubis/lib/store"
 	"github.com/a-h/templ"
+	"github.com/gorilla/mux"
 )
 
 var (
@@ -58,7 +59,7 @@ type ValidateInput struct {
 
 type Impl interface {
 	// Setup registers any additional routes with the Impl for assets or API routes.
-	Setup(mux *http.ServeMux)
+	Setup(r *mux.Router)
 
 	// Issue a new challenge to the user, called by the Anubis.
 	Issue(r *http.Request, lg *slog.Logger, in *IssueInput) (templ.Component, error)

--- a/lib/challenge/metarefresh/metarefresh.go
+++ b/lib/challenge/metarefresh/metarefresh.go
@@ -11,6 +11,7 @@ import (
 	"github.com/TecharoHQ/anubis/lib/localization"
 	"github.com/TecharoHQ/anubis/web"
 	"github.com/a-h/templ"
+	"github.com/gorilla/mux"
 )
 
 //go:generate go tool github.com/a-h/templ/cmd/templ generate
@@ -21,7 +22,7 @@ func init() {
 
 type Impl struct{}
 
-func (i *Impl) Setup(mux *http.ServeMux) {}
+func (i *Impl) Setup(r *mux.Router) {}
 
 func (i *Impl) Issue(r *http.Request, lg *slog.Logger, in *challenge.IssueInput) (templ.Component, error) {
 	u, err := r.URL.Parse(anubis.BasePrefix + "/.within.website/x/cmd/anubis/api/pass-challenge")

--- a/lib/challenge/proofofwork/proofofwork.go
+++ b/lib/challenge/proofofwork/proofofwork.go
@@ -13,6 +13,7 @@ import (
 	"github.com/TecharoHQ/anubis/lib/localization"
 	"github.com/TecharoHQ/anubis/web"
 	"github.com/a-h/templ"
+	"github.com/gorilla/mux"
 )
 
 func init() {
@@ -24,7 +25,7 @@ type Impl struct {
 	Algorithm string
 }
 
-func (i *Impl) Setup(mux *http.ServeMux) {
+func (i *Impl) Setup(r *mux.Router) {
 	/* no implementation required */
 }
 

--- a/lib/challenge/proofofwork/proofofwork_test.go
+++ b/lib/challenge/proofofwork/proofofwork_test.go
@@ -9,6 +9,7 @@ import (
 	"github.com/TecharoHQ/anubis/lib/challenge"
 	"github.com/TecharoHQ/anubis/lib/policy"
 	"github.com/TecharoHQ/anubis/lib/policy/config"
+	"github.com/gorilla/mux"
 )
 
 func mkRequest(t *testing.T, values map[string]string) *http.Request {
@@ -124,7 +125,7 @@ func TestBasic(t *testing.T) {
 		t.Run(cs.name, func(t *testing.T) {
 			lg := slog.With()
 
-			i.Setup(http.NewServeMux())
+			i.Setup(mux.NewRouter())
 
 			inp := &challenge.IssueInput{
 				Rule: bot,

--- a/xess/xess.go
+++ b/xess/xess.go
@@ -10,6 +10,7 @@ import (
 
 	"github.com/TecharoHQ/anubis"
 	"github.com/TecharoHQ/anubis/internal"
+	"github.com/gorilla/mux"
 )
 
 var (
@@ -20,8 +21,6 @@ var (
 )
 
 func init() {
-	Mount(http.DefaultServeMux)
-
 	//goland:noinspection GoBoolExpressions
 	if anubis.Version != "devel" {
 		URL = filepath.Join(filepath.Dir(URL), "xess.min.css")
@@ -31,8 +30,10 @@ func init() {
 }
 
 // Mount registers the xess static file handlers on the given mux
-func Mount(mux *http.ServeMux) {
+func Mount(r *mux.Router) {
 	prefix := anubis.BasePrefix + "/.within.website/x/xess/"
 
-	mux.Handle(prefix, internal.UnchangingCache(http.StripPrefix(prefix, http.FileServerFS(Static))))
+	r.PathPrefix(prefix).
+		Handler(internal.UnchangingCache(http.StripPrefix(prefix, http.FileServerFS(Static)))).
+		Name("xess")
 }


### PR DESCRIPTION
Closes #754

This implementation is flawed, it's making the pass-challenge route return 404s. I'm not entirely sure why this is happening, but I'm pushing this for now in case there's some low hanging fruit.

<!--
delete me and describe your change here, give enough context for a maintainer to understand what and why

See https://anubis.techaro.lol/docs/developer/code-quality for more information
-->

Checklist:

- [ ] Added a description of the changes to the `[Unreleased]` section of docs/docs/CHANGELOG.md
- [ ] Added test cases to [the relevant parts of the codebase](https://anubis.techaro.lol/docs/developer/code-quality)
- [ ] Ran integration tests `npm run test:integration` (unsupported on Windows, please use WSL)
