### PR TITLE
chore(docs): fix typo in configuration/expressions

### DIFF
--- a/docs/docs/admin/configuration/expressions.mdx
+++ b/docs/docs/admin/configuration/expressions.mdx
@@ -123,7 +123,7 @@ In order to avoid this, make sure the header or query parameter you are testing 
     - 'path == "/index.php"'
     - '"title" in query'
     - '"action" in query'
-    - 'query["action"] == "history"
+    - 'query["action"] == "history"'
 ```
 
 This rule throws a challenge if and only if all of the following conditions are true:


### PR DESCRIPTION
Very simple typo fix in the docs, an example code block was missing a closing single quote.

Checklist:

- [ ] Added a description of the changes to the `[Unreleased]` section of docs/docs/CHANGELOG.md
- [ ] Added test cases to [the relevant parts of the codebase](https://anubis.techaro.lol/docs/developer/code-quality)
- [ ] Ran integration tests `npm run test:integration` (unsupported on Windows, please use WSL)
