### PR TITLE
feat(lib): enable multiple consecutive slash support

### DIFF
--- a/docs/docs/CHANGELOG.md
+++ b/docs/docs/CHANGELOG.md
@@ -99,6 +99,7 @@ There are a bunch of other assorted features and fixes too:
 - Allow [Common Crawl](https://commoncrawl.org/) by default so scrapers have less incentive to scrape
 - The [bbolt storage backend](./admin/policies.mdx#bbolt) now runs its cleanup every hour instead of every five minutes.
 - Don't block Anubis starting up if [Thoth](./admin/thoth.mdx) health checks fail.
+- Multiple consecutive slashes are supported in upstream application URLs ([#754](https://github.com/TecharoHQ/anubis/issues/754)).
 
 ### Potentially breaking changes
 

--- a/lib/anubis.go
+++ b/lib/anubis.go
@@ -67,14 +67,15 @@ var (
 )
 
 type Server struct {
-	next        http.Handler
-	mux         *http.ServeMux
-	policy      *policy.ParsedConfig
-	OGTags      *ogtags.OGTagCache
-	ed25519Priv ed25519.PrivateKey
-	hs512Secret []byte
-	opts        Options
-	store       store.Interface
+	next         http.Handler
+	mux          *http.ServeMux
+	policy       *policy.ParsedConfig
+	OGTags       *ogtags.OGTagCache
+	ed25519Priv  ed25519.PrivateKey
+	hs512Secret  []byte
+	opts         Options
+	store        store.Interface
+	internalPath string
 }
 
 func (s *Server) getTokenKeyfunc() jwt.Keyfunc {

--- a/lib/config.go
+++ b/lib/config.go
@@ -154,7 +154,6 @@ func New(opts Options) (*Server, error) {
 
 	registerWithPrefix(anubis.APIPrefix+"pass-challenge", http.HandlerFunc(result.PassChallenge), "GET")
 	registerWithPrefix(anubis.APIPrefix+"check", http.HandlerFunc(result.maybeReverseProxyHttpStatusOnly), "")
-	registerWithPrefix("/", http.HandlerFunc(result.maybeReverseProxyOrPage), "")
 
 	//goland:noinspection GoBoolExpressions
 	if anubis.Version == "devel" {

--- a/lib/config.go
+++ b/lib/config.go
@@ -101,13 +101,14 @@ func New(opts Options) (*Server, error) {
 	anubis.BasePrefix = opts.BasePrefix
 
 	result := &Server{
-		next:        opts.Next,
-		ed25519Priv: opts.ED25519PrivateKey,
-		hs512Secret: opts.HS512Secret,
-		policy:      opts.Policy,
-		opts:        opts,
-		OGTags:      ogtags.NewOGTagCache(opts.Target, opts.Policy.OpenGraph, opts.Policy.Store),
-		store:       opts.Policy.Store,
+		next:         opts.Next,
+		ed25519Priv:  opts.ED25519PrivateKey,
+		hs512Secret:  opts.HS512Secret,
+		policy:       opts.Policy,
+		opts:         opts,
+		OGTags:       ogtags.NewOGTagCache(opts.Target, opts.Policy.OpenGraph, opts.Policy.Store),
+		store:        opts.Policy.Store,
+		internalPath: opts.BasePrefix + anubis.StaticPath,
 	}
 
 	mux := http.NewServeMux()

--- a/lib/http.go
+++ b/lib/http.go
@@ -200,7 +200,12 @@ func (s *Server) respondWithStatus(w http.ResponseWriter, r *http.Request, msg s
 }
 
 func (s *Server) ServeHTTP(w http.ResponseWriter, r *http.Request) {
-	s.mux.ServeHTTP(w, r)
+	switch strings.HasPrefix(r.URL.Path, anubis.StaticPath) {
+	case true:
+		s.mux.ServeHTTP(w, r)
+	case false:
+		s.maybeReverseProxyOrPage(w, r)
+	}
 }
 
 func (s *Server) stripBasePrefixFromRequest(r *http.Request) *http.Request {

--- a/lib/http.go
+++ b/lib/http.go
@@ -200,7 +200,7 @@ func (s *Server) respondWithStatus(w http.ResponseWriter, r *http.Request, msg s
 }
 
 func (s *Server) ServeHTTP(w http.ResponseWriter, r *http.Request) {
-	switch strings.HasPrefix(r.URL.Path, anubis.StaticPath) {
+	switch strings.HasPrefix(r.URL.Path, s.internalPath) {
 	case true:
 		s.mux.ServeHTTP(w, r)
 	case false:


### PR DESCRIPTION
Replaces #808
Closes #754

Some web applications require the ability to include multiple consecutive slashes in a URL. This could be for optional path variables or for wiki article titles that start with a leading slash.

I wasn't aware that the RFC allowed this.

<!--
delete me and describe your change here, give enough context for a maintainer to understand what and why

See https://anubis.techaro.lol/docs/developer/code-quality for more information
-->

Checklist:

- [x] Added a description of the changes to the `[Unreleased]` section of docs/docs/CHANGELOG.md
- [x] Added test cases to [the relevant parts of the codebase](https://anubis.techaro.lol/docs/developer/code-quality)
- [ ] Ran integration tests `npm run test:integration` (unsupported on Windows, please use WSL)
