### PR TITLE
fix(localization): untranslated string in Filipino language 

### DIFF
--- a/lib/localization/locales/fil.json
+++ b/lib/localization/locales/fil.json
@@ -2,7 +2,7 @@
   "loading": "Naglo-load...",
   "why_am_i_seeing": "Bakit nakikita ko ito?",
   "protected_by": "Pinoprotekta ng",
-  "protected_from": "From",
+  "protected_from": "mula sa",
   "made_with": "Ginawa na may ❤️ sa 🇨🇦",
   "mascot_design": "Disenyo ng Maskot ni/ng",
   "ai_companies_explanation": "Nakikita mo ito dahil ang tagapangasiwa ng website na ito ay nag-set up ng Anubis upang protektahan ang server laban sa salot ng mga kumpanya ng AI na aggresibong nagse-scrape ng mga website. Maaari nitong magdulot ng downtime para sa mga website, na gagawing hindi naa-access ang kanilang mga resource para sa lahat.",


### PR DESCRIPTION
<!--
delete me and describe your change here, give enough context for a maintainer to understand what and why

See https://anubis.techaro.lol/docs/developer/code-quality for more information
-->

There's an untranslated string in the Filipino translation files, specifically for the `protected_from` string. I have added a translation for that string.

Checklist:

- [ ] Added a description of the changes to the `[Unreleased]` section of docs/docs/CHANGELOG.md
- [ ] Added test cases to [the relevant parts of the codebase](https://anubis.techaro.lol/docs/developer/code-quality)
- [ ] Ran integration tests `npm run test:integration` (unsupported on Windows, please use WSL)
