### PR TITLE
fix(cmd/anubis): add signal handling to metrics server

### DIFF
--- a/cmd/anubis/main.go
+++ b/cmd/anubis/main.go
@@ -263,7 +263,10 @@ func main() {
 		return
 	}
 
-	ctx := context.Background()
+	// install signal handler
+	ctx, stop := signal.NotifyContext(context.Background(), os.Interrupt, syscall.SIGTERM)
+	defer stop()
+
 	wg := new(sync.WaitGroup)
 
 	if *metricsBind != "" {
@@ -413,10 +416,6 @@ func main() {
 	if err != nil {
 		log.Fatalf("can't construct libanubis.Server: %v", err)
 	}
-
-	// install signal handler
-	ctx, stop := signal.NotifyContext(context.Background(), os.Interrupt, syscall.SIGTERM)
-	defer stop()
 
 	var h http.Handler
 	h = s

--- a/docs/docs/CHANGELOG.md
+++ b/docs/docs/CHANGELOG.md
@@ -13,6 +13,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 <!-- This changes the project to: -->
 
+- Fix hanging on service restart ([#853](https://github.com/TecharoHQ/anubis/issues/853))
+
 ## v1.21.0: Minfilia Warde
 
 > Please, be at ease. You are among friends here.


### PR DESCRIPTION
This fixes a bug that was introduced in 68b653b0, in which the call to metricsServer was passed a plain context.Background without signal handling.

This commit adds back in the signal handling for the metrics server, as well as for the Thoth client and storage backend.

Closes: #853

<!--
delete me and describe your change here, give enough context for a maintainer to understand what and why

See https://anubis.techaro.lol/docs/developer/code-quality for more information
-->

Checklist:

- [x] Added a description of the changes to the `[Unreleased]` section of docs/docs/CHANGELOG.md
- [ ] Added test cases to [the relevant parts of the codebase](https://anubis.techaro.lol/docs/developer/code-quality)
- [ ] Ran integration tests `npm run test:integration` (unsupported on Windows, please use WSL)