### PR TITLE
Pass forward X-Real-IP to nginx backend server

### DIFF
--- a/docs/docs/admin/environments/nginx.mdx
+++ b/docs/docs/admin/environments/nginx.mdx
@@ -79,6 +79,10 @@ server {
   root "/srv/http/anubistest.techaro.lol";
   index index.html;
 
+  # Get the visiting IP from the TLS termination server
+  set_real_ip_from unix:;
+  real_ip_header   X-Real-IP;
+  
   # Your normal configuration can go here
   # location .php { fastcgi...} etc.
 }


### PR DESCRIPTION
The TLS termination server sets X-Real-IP to be used by the back-end, but the back-end configuration example doesn't actually extract it so nginx logs (and back-end processing) fails to log or use the visiting IP in any way (it just states `unix:` if using a unix socket like in the example given, or the local IP if forwarded over TCP).

Adding real_ip_header to the config will fix this.

Checklist:

(this is just a doc change, the checklist didn't apply for this)