### PR TITLE
test(lib): add a test for the X-Forwarded-For middleware

### DIFF
--- a/lib/testdata/permissive.yaml
+++ b/lib/testdata/permissive.yaml
@@ -1,0 +1,4 @@
+bots:
+  - import: (data)/common/allow-private-addresses.yaml
+
+dnsbl: false


### PR DESCRIPTION
Previously the X-Forwarded-For middleware could return two commas in a row. This is a regression test to make sure that doesn't happen again.

Imports a patch previously exclusive to Botstopper.

<!--
delete me and describe your change here, give enough context for a maintainer to understand what and why

See https://anubis.techaro.lol/docs/developer/code-quality for more information
-->

Checklist:

- [ ] Added a description of the changes to the `[Unreleased]` section of docs/docs/CHANGELOG.md
- [ ] Added test cases to [the relevant parts of the codebase](https://anubis.techaro.lol/docs/developer/code-quality)
- [ ] Ran integration tests `npm run test:integration` (unsupported on Windows, please use WSL)
