### PR TITLE
lib/checker: Implement X-Original-URI support

### DIFF
--- a/docs/docs/CHANGELOG.md
+++ b/docs/docs/CHANGELOG.md
@@ -40,6 +40,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Bump AI-robots.txt to version 1.39
 - Add a default block rule for Huawei Cloud.
 - Add a default block rule for Alibaba Cloud.
+- Add X-Request-URI support so that Subrequest Authentication has path support.
 
 ### Security-relevant changes
 

--- a/lib/policy/checker.go
+++ b/lib/policy/checker.go
@@ -102,6 +102,13 @@ func NewPathChecker(rexStr string) (checker.Impl, error) {
 }
 
 func (pc *PathChecker) Check(r *http.Request) (bool, error) {
+	originalUrl := r.Header.Get("X-Original-URI")
+	if originalUrl != "" {
+		if pc.regexp.MatchString(originalUrl) {
+			return true, nil
+		}
+	}
+
 	if pc.regexp.MatchString(r.URL.Path) {
 		return true, nil
 	}


### PR DESCRIPTION
Implemented the checking of X-Original-URI so that the path rules would work when using it with Subrequest Authentication.
Closes #453


Checklist:

- [x] Added a description of the changes to the `[Unreleased]` section of docs/docs/CHANGELOG.md
- [x] Added test cases to [the relevant parts of the codebase](https://anubis.techaro.lol/docs/developer/code-quality)
- [x] Ran integration tests `npm run test:integration` (unsupported on Windows, please use WSL)
