### PR TITLE
docs: add link to preact in challenge list

### DIFF
--- a/docs/docs/admin/configuration/challenges/index.mdx
+++ b/docs/docs/admin/configuration/challenges/index.mdx
@@ -3,6 +3,7 @@
 Anubis supports multiple challenge methods:
 
 - [Meta Refresh](./metarefresh.mdx)
+- [Preact](./preact.mdx)
 - [Proof of Work](./proof-of-work.mdx)
 
 Read the documentation to know which method is best for you.


### PR DESCRIPTION
Preact was added in 1.22, but it currently isn't listed in the "Challenges" page of the documentation. This PR just adds that link.

Checklist:

- [ ] Added a description of the changes to the `[Unreleased]` section of docs/docs/CHANGELOG.md
- [ ] Added test cases to [the relevant parts of the codebase](https://anubis.techaro.lol/docs/developer/code-quality)
- [ ] Ran integration tests `npm run test:integration` (unsupported on Windows, please use WSL)
- [ ] All of my commits have [verified signatures](https://anubis.techaro.lol/docs/developer/signed-commits)

(I'm not exactly sure which items of the above checklist I should be doing. First time here.)