### PR TITLE
fix(run/openrc): truncate runtime directory before starting Anubis

### DIFF
--- a/docs/docs/CHANGELOG.md
+++ b/docs/docs/CHANGELOG.md
@@ -25,6 +25,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Add the `DIFFICULTY_IN_JWT` option, which allows one to add the `difficulty` field in the JWT claims which indicates the difficulty of the token ([#1063](https://github.com/TecharoHQ/anubis/pull/1063)).
 - Ported the client-side JS to TypeScript to avoid egregious errors in the future.
 - Fixes concurrency problems with very old browsers ([#1082](https://github.com/TecharoHQ/anubis/issues/1082)).
+- Update OpenRC service to truncate the runtime directory before starting Anubis.
 
 ### Bug Fixes
 

--- a/run/openrc/anubis.initd
+++ b/run/openrc/anubis.initd
@@ -30,5 +30,6 @@ start_pre() {
 		return 1
 	fi
 
-	checkpath -d -o "${command_user?}" "/run/anubis_${instance?}"
+	rm -rf "/run/anubis_${instance?}"
+	checkpath -D -o "${command_user?}" "/run/anubis_${instance?}"
 }


### PR DESCRIPTION
If Anubis is not shut down correctly and there are leftover socket
files, Anubis will refuse to start.

As "checkpath -D" currently does not work as expected
(https://github.com/OpenRC/openrc/issues/335), simply use "rm -rf"
before starting Anubis.

Checklist:

- [x] Added a description of the changes to the `[Unreleased]` section of docs/docs/CHANGELOG.md
- [ ] Added test cases to [the relevant parts of the codebase](https://anubis.techaro.lol/docs/developer/code-quality)
- [ ] Ran integration tests `npm run test:integration` (unsupported on Windows, please use WSL)
- [x] All of my commits have [verified signatures](https://anubis.techaro.lol/docs/developer/signed-commits)