### PR TITLE
fix: mend auth cookie name stutter

### DIFF
--- a/anubis.go
+++ b/anubis.go
@@ -11,7 +11,7 @@ var Version = "devel"
 
 // CookieName is the name of the cookie that Anubis uses in order to validate
 // access.
-var CookieName = "techaro.lol-anubis-auth"
+var CookieName = "techaro.lol-anubis"
 
 // TestCookieName is the name of the cookie that Anubis uses in order to check
 // if cookies are enabled on the client's browser.

--- a/docs/docs/CHANGELOG.md
+++ b/docs/docs/CHANGELOG.md
@@ -21,6 +21,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Add validation warning when persistent storage is used without setting signing keys.
 - Fixed `robots2policy` to properly group consecutive user agents into `any:` instead of only processing the last one ([#925](https://github.com/TecharoHQ/anubis/pull/925)).
 - Add the [`s3api` storage backend](./admin/policies.mdx#s3api) to allow Anubis to use S3 API compatible object storage as its storage backend.
+- Fix a "stutter" in the cookie name prefix so the auth cookie is named `techaro.lol-anubis-auth` instead of `techaro.lol-anubis-auth-auth`.
 - Make `cmd/containerbuild` support commas for separating elements of the `--docker-tags` argument as well as newlines.
 - Add the `DIFFICULTY_IN_JWT` option, which allows one to add the `difficulty` field in the JWT claims which indicates the difficulty of the token ([#1063](https://github.com/TecharoHQ/anubis/pull/1063)).
 - Ported the client-side JS to TypeScript to avoid egregious errors in the future.


### PR DESCRIPTION
The cookies are named `techaro.lol-anubis-auth-auth` instead of just `techaro.lol-anubis-auth`. This patch fixes that.

Checklist:

- [x] Added a description of the changes to the `[Unreleased]` section of docs/docs/CHANGELOG.md
- [ ] Added test cases to [the relevant parts of the codebase](https://anubis.techaro.lol/docs/developer/code-quality)
- [ ] Ran integration tests `npm run test:integration` (unsupported on Windows, please use WSL)
- [x] All of my commits have [verified signatures](https://anubis.techaro.lol/docs/developer/signed-commits)
