### PR TITLE
link to docs site from readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -66,7 +66,7 @@ Anubis is a bit of a nuclear response. This will result in your website being bl
 
 In most cases, you should not need this and can probably get by using Cloudflare to protect a given origin. However, for circumstances where you can't or won't use Cloudflare, Anubis is there for you.
 
-If you want to try this out, connect to [anubis.techaro.lol](https://anubis.techaro.lol).
+If you want to try this out, visit the Anubis documentation site at [anubis.techaro.lol](https://anubis.techaro.lol).
 
 ## Support
 


### PR DESCRIPTION
I'm unfamiliar with Anubis and didn't see a link to the docs site in the readme because it's labeled as a demo.

No code changes.