### PR TITLE
chore(default-config): remove Tencent Cloud block rule

### DIFF
--- a/data/bots/_deny-pathological.yaml
+++ b/data/bots/_deny-pathological.yaml
@@ -4,4 +4,3 @@
 - import: (data)/bots/custom-async-http-client.yaml
 - import: (data)/crawlers/alibaba-cloud.yaml
 - import: (data)/crawlers/huawei-cloud.yaml
-- import: (data)/crawlers/tencent-cloud.yaml

--- a/docs/docs/CHANGELOG.md
+++ b/docs/docs/CHANGELOG.md
@@ -14,6 +14,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 <!-- This changes the project to: -->
 
 - Fix `SERVE_ROBOTS_TXT` setting file after the double slash fix broke it.
+- Remove the default configuration rule to block Tencent cloud. If users see abuse from Tencent cloud IP ranges, please contact abuse@tencent.com and mention that you are using Anubis to protect your services. Please include source IP address, source port, timestamp, target IP address, target port, request headers (including the User-Agent header), and target endpoints/patterns.
 
 ## v1.23.0: Lyse Hext
 


### PR DESCRIPTION
Tencent Cloud's abuse team reached out to me recently and asked for this rule to be removed. Prior attempts to reach out to them to report abusive traffic have failed, thus leading to this IP space block as a last resort to try and maintain uptime for systems administrators.

This patch is an olive branch. If Tencent Cloud's abuse team can actually make promises and back them up with action that results in a notable lessening of abusive scraping from their IP ranges, this block can be removed.

<!--
delete me and describe your change here, give enough context for a maintainer to understand what and why

See https://anubis.techaro.lol/docs/developer/code-quality for more information
-->

Checklist:

- [x] Added a description of the changes to the `[Unreleased]` section of docs/docs/CHANGELOG.md
- [ ] Added test cases to [the relevant parts of the codebase](https://anubis.techaro.lol/docs/developer/code-quality)
- [ ] Ran integration tests `npm run test:integration` (unsupported on Windows, please use WSL)
- [x] All of my commits have [verified signatures](https://anubis.techaro.lol/docs/developer/signed-commits)
