### PR TITLE
chore(default-config): add chromey version number check

### DIFF
--- a/data/botPolicies.yaml
+++ b/data/botPolicies.yaml
@@ -134,6 +134,16 @@ bots:
     weight:
       adjust: -5
 
+  # Chrome should send versions of form 130.0.0.0 in its user agent string.
+  - name: chrome-version-simplified
+    expression:
+      all:
+        - userAgent.contains("Chrome")
+        - userAgent.matches("Chrome/1[3-9][0-9]\\.0\\.0\\.0")
+    action: WEIGH
+    weight:
+      adjust: -5
+
   - name: should-have-accept
     expression: '!("Accept" in headers)'
     action: WEIGH

--- a/data/meta/default-config.yaml
+++ b/data/meta/default-config.yaml
@@ -118,6 +118,16 @@
   weight:
     adjust: -5
 
+# Chrome should send versions of form 130.0.0.0 in its user agent string.
+- name: chrome-version-simplified
+  expression:
+    all:
+      - userAgent.contains("Chrome")
+      - userAgent.matches("Chrome/1[3-9][0-9]\\.0\\.0\\.0")
+  action: WEIGH
+  weight:
+    adjust: -5
+
 - name: should-have-accept
   expression: '!("Accept" in headers)'
   action: WEIGH

--- a/docs/docs/CHANGELOG.md
+++ b/docs/docs/CHANGELOG.md
@@ -15,6 +15,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 - Fix `SERVE_ROBOTS_TXT` setting file after the double slash fix broke it.
 - Remove the default configuration rule to block Tencent cloud. If users see abuse from Tencent cloud IP ranges, please contact abuse@tencent.com and mention that you are using Anubis to protect your services. Please include source IP address, source port, timestamp, target IP address, target port, request headers (including the User-Agent header), and target endpoints/patterns.
+- Add a deweighing rule that removes 5 weight points if a client uses Google Chrome and the version number in the user agent is "chromey enough".
 
 ## v1.23.0: Lyse Hext
 


### PR DESCRIPTION
Google Chrome sends version numbers in the form of:

```
Chrome/130.0.0.0
```

Let's take advantage of that!

Checklist:

- [x] Added a description of the changes to the `[Unreleased]` section of docs/docs/CHANGELOG.md
- [ ] Added test cases to [the relevant parts of the codebase](https://anubis.techaro.lol/docs/developer/code-quality)
- [x] Ran integration tests `npm run test:integration` (unsupported on Windows, please use WSL)
- [x] All of my commits have [verified signatures](https://anubis.techaro.lol/docs/developer/signed-commits)
