### PR TITLE
docs: use nginx http2 directive instead of deprecated http2 listen parameter

### DIFF
--- a/docs/docs/admin/environments/nginx.mdx
+++ b/docs/docs/admin/environments/nginx.mdx
@@ -55,8 +55,9 @@ server {
 # proxy all traffic to the target via Anubis.
 server {
   # Listen on TCP port 443 with TLS (https) and HTTP/2
-  listen 443 ssl http2;
-  listen [::]:443 ssl http2;
+  listen 443 ssl;
+  listen [::]:443 ssl;
+  http2 on;
 
   location / {
     proxy_set_header Host $host;
@@ -113,8 +114,9 @@ Then in a server block:
 
 server {
   # Listen on 443 with SSL
-  listen 443 ssl http2;
-  listen [::]:443 ssl http2;
+  listen 443 ssl;
+  listen [::]:443 ssl;
+  http2 on;
 
   # Slipstream via Anubis
   include "conf-anubis.inc";


### PR DESCRIPTION
the nginx listen directive's http2 parameter is deprecated in favor of the nginx http2 directive.

https://nginx.org/en/docs/http/ngx_http_core_module.html#listen
https://nginx.org/en/docs/http/ngx_http_v2_module.html#http2

Checklist:

- skipped for now, docs change, and codespaces is being phobic today
  - [ ] Added a description of the changes to the `[Unreleased]` section of docs/docs/CHANGELOG.md
  - [ ] Added test cases to [the relevant parts of the codebase](https://anubis.techaro.lol/docs/developer/code-quality)
  - [ ] Ran integration tests `npm run test:integration` (unsupported on Windows, please use WSL)
- [X] All of my commits have [verified signatures](https://anubis.techaro.lol/docs/developer/signed-commits)
