### PR TITLE
Add Renovate to Docker clients

### DIFF
--- a/data/clients/docker-client.yaml
+++ b/data/clients/docker-client.yaml
@@ -51,3 +51,10 @@
     all:
       - path.startsWith("/v2/")
       - userAgent.contains("containerd/")
+
+- name: allow-renovate
+  action: ALLOW
+  expression:
+    all:
+      - path.startsWith("/v2/")
+      - userAgent.contains("Renovate/")

--- a/docs/docs/CHANGELOG.md
+++ b/docs/docs/CHANGELOG.md
@@ -16,6 +16,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Allow more OCI registry clients [based on feedback](https://github.com/TecharoHQ/anubis/pull/1253#issuecomment-3506744184).
 - Expose services directory in the embedded `(data)` filesystem.
 - Add Ukrainian locale ([#1044](https://github.com/TecharoHQ/anubis/pull/1044))
+- Allow Renovate as an OCI registry client
 
 ## v1.23.1: Lyse Hext - Echo 1
 


### PR DESCRIPTION
Renovate-bot looks at the container APIs directly to learn about new image versions and digests. The [default User-Agent](https://docs.renovatebot.com/self-hosted-configuration/#useragent) is `Renovate/${renovateVersion} (https://github.com/renovatebot/renovate)`

Checklist:

- [x] Added a description of the changes to the `[Unreleased]` section of docs/docs/CHANGELOG.md
- [ ] Added test cases to [the relevant parts of the codebase](https://anubis.techaro.lol/docs/developer/code-quality)
  - I didn't think it's worth it - this is basically a config update similar to #1258
- [ ] Ran integration tests `npm run test:integration` (unsupported on Windows, please use WSL)
  - I didn't think it was worth it - I've manually tested the rule in my own deployment
- [x] All of my commits have [verified signatures](https://anubis.techaro.lol/docs/developer/signed-commits)
