### PR TITLE
feat(internal/headers): extend debug logging of X-Forwarded-For middlewares

### DIFF
--- a/internal/headers.go
+++ b/internal/headers.go
@@ -87,7 +87,7 @@ func XForwardedForToXRealIP(next http.Handler) http.Handler {
 	return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		if xffHeader := r.Header.Get("X-Forwarded-For"); r.Header.Get("X-Real-Ip") == "" && xffHeader != "" {
 			ip := xff.Parse(xffHeader)
-			slog.Debug("setting x-real-ip", "val", ip)
+			slog.Debug("setting X-Real-Ip from X-Forwarded-For", "to", ip, "x-forwarded-for", xffHeader)
 			r.Header.Set("X-Real-Ip", ip)
 		}
 
@@ -129,6 +129,8 @@ func XForwardedForUpdate(stripPrivate bool, next http.Handler) http.Handler {
 		} else {
 			r.Header.Set("X-Forwarded-For", xffHeaderString)
 		}
+
+		slog.Debug("updating X-Forwarded-For", "original", origXFFHeader, "new", xffHeaderString)
 	})
 }
 


### PR DESCRIPTION
Main motivation behind this change is to aid with future debugging of the middlewares that use and update the `X-Forwarded-For` header.

(I'm currently investigating an issue where I first needed to find out what the original `X-Forwarded-For` header transmitted to Anubis looked like.)

Checklist:

- [ ] Added a description of the changes to the `[Unreleased]` section of docs/docs/CHANGELOG.md
- [ ] Added test cases to [the relevant parts of the codebase](https://anubis.techaro.lol/docs/developer/code-quality)
- [ ] Ran integration tests `npm run test:integration` (unsupported on Windows, please use WSL)
- [x] All of my commits have [verified signatures](https://anubis.techaro.lol/docs/developer/signed-commits)
