### PR TITLE
test: Valkey test improvements for testcontainers

### DIFF
--- a/lib/store/valkey/valkey_test.go
+++ b/lib/store/valkey/valkey_test.go
@@ -5,15 +5,10 @@ import (
 	"os"
 	"testing"
 
-	"github.com/TecharoHQ/anubis/internal"
 	"github.com/TecharoHQ/anubis/lib/store/storetest"
 	"github.com/testcontainers/testcontainers-go"
 	"github.com/testcontainers/testcontainers-go/wait"
 )
-
-func init() {
-	internal.UnbreakDocker()
-}
 
 func TestImpl(t *testing.T) {
 	if os.Getenv("DONT_USE_NETWORK") != "" {


### PR DESCRIPTION
Use the endpoint feature to get the connection URL for the container.

There are cases where localhost is not the correct one, for example when DOCKER_HOST is set to another machine.

Also, don't specify the external port for the mapping so a random unused port is used, in cases when there is already Valkey/Redis running as a container and port mapped externally on 6379.

It also works in the dev container.

Checklist:

- [ ] Added a description of the changes to the `[Unreleased]` section of docs/docs/CHANGELOG.md
- [x] Added test cases to [the relevant parts of the codebase](https://anubis.techaro.lol/docs/developer/code-quality)
- [x] Ran integration tests `npm run test:integration` (unsupported on Windows, please use WSL)
- [x] All of my commits have [verified signatures](https://anubis.techaro.lol/docs/developer/signed-commits)
