### PR TITLE
Pass the remote IP to the proxied application

### DIFF
--- a/.github/actions/spelling/expect.txt
+++ b/.github/actions/spelling/expect.txt
@@ -276,6 +276,7 @@ redhat
 redir
 redirectscheme
 refactors
+remoteip
 reputational
 risc
 ruleset

--- a/docs/docs/admin/environments/apache.mdx
+++ b/docs/docs/admin/environments/apache.mdx
@@ -92,6 +92,11 @@ Assuming you are protecting `anubistest.techaro.lol`, you need the following ser
        DocumentRoot /var/www/anubistest.techaro.lol
        ErrorLog /var/log/httpd/anubistest.techaro.lol_error.log
        CustomLog /var/log/httpd/anubistest.techaro.lol_access.log combined
+
+       # Pass the remote IP to the proxied application instead of 127.0.0.1
+       # This requires mod_remoteip
+       RemoteIPHeader X-Real-IP
+       RemoteIPTrustedProxy 127.0.0.1/32
 </VirtualHost>
 ```
 


### PR DESCRIPTION
With the default suggested config, all proxied applications will only receive 127.0.0.1 as remote IP (e.g. PHP site's `$_SERVER['REMOTE_ADDR']`). While the config already implements the forwarding headers on the proxy side, the IP capturing on the application site didn't exist.

This is relevant for:
- Access logs
- Audit logs
- Statistics
- Spam protection that validate IP address scores

Checklist:

- [ ] Added a description of the changes to the `[Unreleased]` section of docs/docs/CHANGELOG.md
- [ ] Added test cases to [the relevant parts of the codebase](https://anubis.techaro.lol/docs/developer/code-quality)
- [ ] Ran integration tests `npm run test:integration` (unsupported on Windows, please use WSL)
- [x] All of my commits have [verified signatures](https://anubis.techaro.lol/docs/developer/signed-commits)