### PR TITLE
Update docker-client.yaml with skopeo

### DIFF
--- a/data/clients/docker-client.yaml
+++ b/data/clients/docker-client.yaml
@@ -58,3 +58,10 @@
     all:
       - path.startsWith("/v2/")
       - userAgent.contains("Renovate/")
+
+- name: allow-skopeo
+  action: ALLOW
+  expression:
+    all:
+      - path.startsWith("/v2/")
+      - userAgent.contains("skopeo/")

--- a/docs/docs/CHANGELOG.md
+++ b/docs/docs/CHANGELOG.md
@@ -23,6 +23,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Add support to simple Valkey/Redis cluster mode
 - Open Graph passthrough now reuses the configured target Host/SNI/TLS settings, so metadata fetches succeed when the upstream certificate differs from the public domain. ([1283](https://github.com/TecharoHQ/anubis/pull/1283))
 - Stabilize the CVE-2025-24369 regression test by always submitting an invalid proof instead of relying on random POW failures.
+- Add Skopeo to the builtin list of common Docker clients
 
 ### Deprecate `report_as` in challenge configuration
 


### PR DESCRIPTION
the skopeo user agent is not in the default OCI client allowlist. https://github.com/containers/skopeo/blob/f358adffdd71ea84f200597e1c9b8cc28ada3348/cmd/skopeo/main.go#L19

<!--
delete me and describe your change here, give enough context for a maintainer to understand what and why

See https://anubis.techaro.lol/docs/developer/code-quality for more information
-->

Checklist:

- [X] Added a description of the changes to the `[Unreleased]` section of docs/docs/CHANGELOG.md
- [ ] ~~Added test cases to [the relevant parts of the codebase](https://anubis.techaro.lol/docs/developer/code-quality)~~
- [ ] ~~Ran integration tests `npm run test:integration` (unsupported on Windows, please use WSL)~~
- [ ] All of my commits have [verified signatures](https://anubis.techaro.lol/docs/developer/signed-commits)
