### PR TITLE
fix(default-config): must-accept-rule on browsers only

### DIFF
--- a/data/botPolicies.yaml
+++ b/data/botPolicies.yaml
@@ -134,7 +134,10 @@ bots:
       adjust: -5
 
   - name: should-have-accept
-    expression: '!("Accept" in headers)'
+    expression:
+      all:
+        - userAgent.contains("Mozilla")
+        - '!("Accept" in headers)'
     action: WEIGH
     weight:
       adjust: 5

--- a/data/meta/default-config.yaml
+++ b/data/meta/default-config.yaml
@@ -118,7 +118,10 @@
     adjust: -5
 
 - name: should-have-accept
-  expression: '!("Accept" in headers)'
+  expression:
+    all:
+      - userAgent.contains("Mozilla")
+      - '!("Accept" in headers)'
   action: WEIGH
   weight:
     adjust: 5

--- a/docs/docs/CHANGELOG.md
+++ b/docs/docs/CHANGELOG.md
@@ -27,6 +27,7 @@ Anubis is back and better than ever! Lots of minor fixes with some big ones inte
 - Add support to simple Valkey/Redis cluster mode
 - Open Graph passthrough now reuses the configured target Host/SNI/TLS settings, so metadata fetches succeed when the upstream certificate differs from the public domain. ([1283](https://github.com/TecharoHQ/anubis/pull/1283))
 - Stabilize the CVE-2025-24369 regression test by always submitting an invalid proof instead of relying on random POW failures.
+- Refine the check that ensures the presence of the Accept header to avoid breaking docker clients.
 
 ### Dataset poisoning
 


### PR DESCRIPTION
TIL docker clients don't include the Accept header all the time. I would have thought they did that. Oops.

Closes: #1346

<!--
delete me and describe your change here, give enough context for a maintainer to understand what and why

See https://anubis.techaro.lol/docs/developer/code-quality for more information
-->

Checklist:

- [x] Added a description of the changes to the `[Unreleased]` section of docs/docs/CHANGELOG.md
- [ ] Added test cases to [the relevant parts of the codebase](https://anubis.techaro.lol/docs/developer/code-quality)
- [x] Ran integration tests `npm run test:integration` (unsupported on Windows, please use WSL)
- [x] All of my commits have [verified signatures](https://anubis.techaro.lol/docs/developer/signed-commits)
