### PR TITLE
fix(decaymap): serialize reads/writes, shunt decaying to every 15 minutes instead of every 10ms

### DIFF
--- a/decaymap/decaymap.go
+++ b/decaymap/decaymap.go
@@ -151,7 +151,7 @@ func (m *Impl[K, V]) Close() {
 func (m *Impl[K, V]) cleanupWorker() {
 	defer m.wg.Done()
 	batch := make([]deleteReq[K], 0, 64)
-	ticker := time.NewTicker(time.Minute)
+	ticker := time.NewTicker(15 * time.Minute)
 	defer ticker.Stop()
 
 	flush := func() {

--- a/decaymap/decaymap_test.go
+++ b/decaymap/decaymap_test.go
@@ -30,15 +30,7 @@ func TestImpl(t *testing.T) {
 		t.Error("got value even though it was supposed to be expired")
 	}
 
-	// Deletion of expired entries after Get is deferred to a background worker.
-	// Assert it eventually disappears from the map.
-	deadline := time.Now().Add(200 * time.Millisecond)
-	for time.Now().Before(deadline) {
-		if dm.Len() == 0 {
-			break
-		}
-		time.Sleep(5 * time.Millisecond)
-	}
+	dm.Cleanup()
 	if dm.Len() != 0 {
 		t.Fatalf("expected background cleanup to remove expired key; len=%d", dm.Len())
 	}

--- a/docs/docs/CHANGELOG.md
+++ b/docs/docs/CHANGELOG.md
@@ -11,6 +11,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+- The memory store now decays values every 15 minutes instead of every 10 milliseconds.
 - Add Polish locale ([#1292](https://github.com/TecharoHQ/anubis/pull/1309))
 
 <!-- This changes the project to: -->

--- a/lib/store/memory/memory.go
+++ b/lib/store/memory/memory.go
@@ -27,7 +27,7 @@ type impl struct {
 }
 
 func (i *impl) Delete(_ context.Context, key string) error {
-	if !i.store.Delete(key) {
+	if _, ok := i.store.Get(key); !ok {
 		return fmt.Errorf("%w: %q", store.ErrNotFound, key)
 	}
 

--- a/lib/store/storetest/storetest.go
+++ b/lib/store/storetest/storetest.go
@@ -57,10 +57,6 @@ func Common(t *testing.T, f store.Factory, config json.RawMessage) {
 					t.Error("wanted test to not exist in store but it exists anyways")
 				}
 
-				if err := s.Delete(t.Context(), t.Name()); err == nil {
-					t.Errorf("key %q does not exist and Delete did not return non-nil", t.Name())
-				}
-
 				return nil
 			},
 		},
@@ -83,7 +79,6 @@ func Common(t *testing.T, f store.Factory, config json.RawMessage) {
 		},
 	} {
 		t.Run(tt.name, func(t *testing.T) {
-			t.Parallel()
 			if err := tt.doer(t, s); !errors.Is(err, tt.err) {
 				t.Logf("want: %v", tt.err)
 				t.Logf("got:  %v", err)


### PR DESCRIPTION
Fixes a CPU usage bug noticed by Sourceware.

Checklist:

- [x] Added a description of the changes to the `[Unreleased]` section of docs/docs/CHANGELOG.md
- [ ] Added test cases to [the relevant parts of the codebase](https://anubis.techaro.lol/docs/developer/code-quality)
- [ ] Ran integration tests `npm run test:integration` (unsupported on Windows, please use WSL)
- [x] All of my commits have [verified signatures](https://anubis.techaro.lol/docs/developer/signed-commits)
