### PR TITLE
Proxy Protocol Implementation

### DIFF
--- a/cmd/anubis/main.go
+++ b/cmd/anubis/main.go
@@ -79,6 +79,7 @@ var (
 	proxyProtocolAllowedCIDRs      = flag.String("proxy-protocol-allowed-cidrs", "", "List of CIDRs or IPs seperated by commas from which to accept Proxy Headers to fill in the servers information about the requests source address")
 	proxyProtocolPolicy            = flag.String("proxy-protocol-policy", "", "The Policy to be used if the Connection doesn't come from allowed cidrs, possible: IGNORE, REJECT, IGNORE ignores the proxy headers, REJECT rejects the whole connection")
 	proxyProtocolReadHeaderTimeout = flag.Duration("proxy-protocol-read-header-timeout", 5*time.Second, "The Duration in which the ProxyHeaders should be received, if Proxy Protocol IGNORE is set to let traffic without Proxy Protcol Headers pass through this should be set lower")
+	proxyProtocolSendVersion       = flag.String("proxy-protocol-send-version", "", "The Version of Proxy Protocol and if to send to the target, possible values: v1, v2")
 	debugBenchmarkJS               = flag.Bool("debug-benchmark-js", false, "respond to every request with a challenge for benchmarking hashrate")
 	ogPassthrough                  = flag.Bool("og-passthrough", false, "enable Open Graph tag passthrough")
 	ogTimeToLive                   = flag.Duration("og-expiry-time", 24*time.Hour, "Open Graph tag cache expiration time")
@@ -499,7 +500,7 @@ func main() {
 	h = internal.XForwardedForToXRealIP(h)
 	h = internal.XForwardedForUpdate(*xffStripPrivate, h)
 	h = internal.JA4H(h)
-	h = internal.ProxyProtocol(*useProxyProtocol, h)
+	h = internal.ProxyProtocol(*useProxyProtocol, *proxyProtocolSendVersion, h)
 
 	srv := http.Server{Handler: h, ErrorLog: internal.GetFilteredHTTPLogger()}
 	listener, listenerUrl := setupListener(*bindNetwork, *bind)

--- a/cmd/anubis/main.go
+++ b/cmd/anubis/main.go
@@ -43,50 +43,52 @@ import (
 )
 
 var (
-	basePrefix                = flag.String("base-prefix", "", "base prefix (root URL) the application is served under e.g. /myapp")
-	bind                      = flag.String("bind", ":8923", "network address to bind HTTP to")
-	bindNetwork               = flag.String("bind-network", "tcp", "network family to bind HTTP to, e.g. unix, tcp")
-	challengeDifficulty       = flag.Int("difficulty", anubis.DefaultDifficulty, "difficulty of the challenge")
-	cookieDomain              = flag.String("cookie-domain", "", "if set, the top-level domain that the Anubis cookie will be valid for")
-	cookieDynamicDomain       = flag.Bool("cookie-dynamic-domain", false, "if set, automatically set the cookie Domain value based on the request domain")
-	cookieExpiration          = flag.Duration("cookie-expiration-time", anubis.CookieDefaultExpirationTime, "The amount of time the authorization cookie is valid for")
-	cookiePrefix              = flag.String("cookie-prefix", anubis.CookieName, "prefix for browser cookies created by Anubis")
-	cookiePartitioned         = flag.Bool("cookie-partitioned", false, "if true, sets the partitioned flag on Anubis cookies, enabling CHIPS support")
-	difficultyInJWT           = flag.Bool("difficulty-in-jwt", false, "if true, adds a difficulty field in the JWT claims")
-	useSimplifiedExplanation  = flag.Bool("use-simplified-explanation", false, "if true, replaces the text when clicking \"Why am I seeing this?\" with a more simplified text for a non-tech-savvy audience.")
-	forcedLanguage            = flag.String("forced-language", "", "if set, this language is being used instead of the one from the request's Accept-Language header")
-	hs512Secret               = flag.String("hs512-secret", "", "secret used to sign JWTs, uses ed25519 if not set")
-	cookieSecure              = flag.Bool("cookie-secure", true, "if true, sets the secure flag on Anubis cookies")
-	cookieSameSite            = flag.String("cookie-same-site", "None", "sets the same site option on Anubis cookies, will auto-downgrade None to Lax if cookie-secure is false. Valid values are None, Lax, Strict, and Default.")
-	ed25519PrivateKeyHex      = flag.String("ed25519-private-key-hex", "", "private key used to sign JWTs, if not set a random one will be assigned")
-	ed25519PrivateKeyHexFile  = flag.String("ed25519-private-key-hex-file", "", "file name containing value for ed25519-private-key-hex")
-	metricsBind               = flag.String("metrics-bind", ":9090", "network address to bind metrics to")
-	metricsBindNetwork        = flag.String("metrics-bind-network", "tcp", "network family for the metrics server to bind to")
-	socketMode                = flag.String("socket-mode", "0770", "socket mode (permissions) for unix domain sockets.")
-	robotsTxt                 = flag.Bool("serve-robots-txt", false, "serve a robots.txt file that disallows all robots")
-	policyFname               = flag.String("policy-fname", "", "full path to anubis policy document (defaults to a sensible built-in policy)")
-	redirectDomains           = flag.String("redirect-domains", "", "list of domains separated by commas which anubis is allowed to redirect to. Leaving this unset allows any domain.")
-	slogLevel                 = flag.String("slog-level", "INFO", "logging level (see https://pkg.go.dev/log/slog#hdr-Levels)")
-	stripBasePrefix           = flag.Bool("strip-base-prefix", false, "if true, strips the base prefix from requests forwarded to the target server")
-	target                    = flag.String("target", "http://localhost:3923", "target to reverse proxy to, set to an empty string to disable proxying when only using auth request")
-	targetSNI                 = flag.String("target-sni", "", "if set, TLS handshake hostname when forwarding requests to the target, if set to auto, use Host header")
-	targetHost                = flag.String("target-host", "", "if set, the value of the Host header when forwarding requests to the target")
-	targetInsecureSkipVerify  = flag.Bool("target-insecure-skip-verify", false, "if true, skips TLS validation for the backend")
-	targetDisableKeepAlive    = flag.Bool("target-disable-keepalive", false, "if true, disables HTTP keep-alive for the backend")
-	healthcheck               = flag.Bool("healthcheck", false, "run a health check against Anubis")
-	useRemoteAddress          = flag.Bool("use-remote-address", false, "read the client's IP address from the network request, useful for debugging and running Anubis on bare metal")
-	useProxyProtocol          = flag.Bool("use-proxy-protocol", false, "read the client's IP address from the proxy protocol header of an incoming connection (see https://www.haproxy.org/download/1.8/doc/proxy-protocol.txt)")
-	proxyProtocolAllowedCIDRs = flag.String("proxy-protocol-allowed-cidrs", "", "List of CIDRs or IPs seperated by commas from which to accept Proxy Headers to fill in the servers information about the requests source address")
-	debugBenchmarkJS          = flag.Bool("debug-benchmark-js", false, "respond to every request with a challenge for benchmarking hashrate")
-	ogPassthrough             = flag.Bool("og-passthrough", false, "enable Open Graph tag passthrough")
-	ogTimeToLive              = flag.Duration("og-expiry-time", 24*time.Hour, "Open Graph tag cache expiration time")
-	ogCacheConsiderHost       = flag.Bool("og-cache-consider-host", false, "enable or disable the use of the host in the Open Graph tag cache")
-	extractResources          = flag.String("extract-resources", "", "if set, extract the static resources to the specified folder")
-	webmasterEmail            = flag.String("webmaster-email", "", "if set, displays webmaster's email on the reject page for appeals")
-	versionFlag               = flag.Bool("version", false, "print Anubis version")
-	publicUrl                 = flag.String("public-url", "", "the externally accessible URL for this Anubis instance, used for constructing redirect URLs (e.g., for forwardAuth).")
-	xffStripPrivate           = flag.Bool("xff-strip-private", true, "if set, strip private addresses from X-Forwarded-For")
-	customRealIPHeader        = flag.String("custom-real-ip-header", "", "if set, read remote IP from header of this name (in case your environment doesn't set X-Real-IP header)")
+	basePrefix                     = flag.String("base-prefix", "", "base prefix (root URL) the application is served under e.g. /myapp")
+	bind                           = flag.String("bind", ":8923", "network address to bind HTTP to")
+	bindNetwork                    = flag.String("bind-network", "tcp", "network family to bind HTTP to, e.g. unix, tcp")
+	challengeDifficulty            = flag.Int("difficulty", anubis.DefaultDifficulty, "difficulty of the challenge")
+	cookieDomain                   = flag.String("cookie-domain", "", "if set, the top-level domain that the Anubis cookie will be valid for")
+	cookieDynamicDomain            = flag.Bool("cookie-dynamic-domain", false, "if set, automatically set the cookie Domain value based on the request domain")
+	cookieExpiration               = flag.Duration("cookie-expiration-time", anubis.CookieDefaultExpirationTime, "The amount of time the authorization cookie is valid for")
+	cookiePrefix                   = flag.String("cookie-prefix", anubis.CookieName, "prefix for browser cookies created by Anubis")
+	cookiePartitioned              = flag.Bool("cookie-partitioned", false, "if true, sets the partitioned flag on Anubis cookies, enabling CHIPS support")
+	difficultyInJWT                = flag.Bool("difficulty-in-jwt", false, "if true, adds a difficulty field in the JWT claims")
+	useSimplifiedExplanation       = flag.Bool("use-simplified-explanation", false, "if true, replaces the text when clicking \"Why am I seeing this?\" with a more simplified text for a non-tech-savvy audience.")
+	forcedLanguage                 = flag.String("forced-language", "", "if set, this language is being used instead of the one from the request's Accept-Language header")
+	hs512Secret                    = flag.String("hs512-secret", "", "secret used to sign JWTs, uses ed25519 if not set")
+	cookieSecure                   = flag.Bool("cookie-secure", true, "if true, sets the secure flag on Anubis cookies")
+	cookieSameSite                 = flag.String("cookie-same-site", "None", "sets the same site option on Anubis cookies, will auto-downgrade None to Lax if cookie-secure is false. Valid values are None, Lax, Strict, and Default.")
+	ed25519PrivateKeyHex           = flag.String("ed25519-private-key-hex", "", "private key used to sign JWTs, if not set a random one will be assigned")
+	ed25519PrivateKeyHexFile       = flag.String("ed25519-private-key-hex-file", "", "file name containing value for ed25519-private-key-hex")
+	metricsBind                    = flag.String("metrics-bind", ":9090", "network address to bind metrics to")
+	metricsBindNetwork             = flag.String("metrics-bind-network", "tcp", "network family for the metrics server to bind to")
+	socketMode                     = flag.String("socket-mode", "0770", "socket mode (permissions) for unix domain sockets.")
+	robotsTxt                      = flag.Bool("serve-robots-txt", false, "serve a robots.txt file that disallows all robots")
+	policyFname                    = flag.String("policy-fname", "", "full path to anubis policy document (defaults to a sensible built-in policy)")
+	redirectDomains                = flag.String("redirect-domains", "", "list of domains separated by commas which anubis is allowed to redirect to. Leaving this unset allows any domain.")
+	slogLevel                      = flag.String("slog-level", "INFO", "logging level (see https://pkg.go.dev/log/slog#hdr-Levels)")
+	stripBasePrefix                = flag.Bool("strip-base-prefix", false, "if true, strips the base prefix from requests forwarded to the target server")
+	target                         = flag.String("target", "http://localhost:3923", "target to reverse proxy to, set to an empty string to disable proxying when only using auth request")
+	targetSNI                      = flag.String("target-sni", "", "if set, TLS handshake hostname when forwarding requests to the target, if set to auto, use Host header")
+	targetHost                     = flag.String("target-host", "", "if set, the value of the Host header when forwarding requests to the target")
+	targetInsecureSkipVerify       = flag.Bool("target-insecure-skip-verify", false, "if true, skips TLS validation for the backend")
+	targetDisableKeepAlive         = flag.Bool("target-disable-keepalive", false, "if true, disables HTTP keep-alive for the backend")
+	healthcheck                    = flag.Bool("healthcheck", false, "run a health check against Anubis")
+	useRemoteAddress               = flag.Bool("use-remote-address", false, "read the client's IP address from the network request, useful for debugging and running Anubis on bare metal")
+	useProxyProtocol               = flag.Bool("use-proxy-protocol", false, "read the client's IP address from the proxy protocol header of an incoming connection (see https://www.haproxy.org/download/1.8/doc/proxy-protocol.txt)")
+	proxyProtocolAllowedCIDRs      = flag.String("proxy-protocol-allowed-cidrs", "", "List of CIDRs or IPs seperated by commas from which to accept Proxy Headers to fill in the servers information about the requests source address")
+	proxyProtocolPolicy            = flag.String("proxy-protocol-policy", "", "The Policy to be used if the Connection doesn't come from allowed cidrs, possible: IGNORE, REJECT, IGNORE ignores the proxy headers, REJECT rejects the whole connection")
+	proxyProtocolReadHeaderTimeout = flag.Duration("proxy-protocol-read-header-timeout", 5*time.Second, "The Duration in which the ProxyHeaders should be received, if Proxy Protocol IGNORE is set to let traffic without Proxy Protcol Headers pass through this should be set lower")
+	debugBenchmarkJS               = flag.Bool("debug-benchmark-js", false, "respond to every request with a challenge for benchmarking hashrate")
+	ogPassthrough                  = flag.Bool("og-passthrough", false, "enable Open Graph tag passthrough")
+	ogTimeToLive                   = flag.Duration("og-expiry-time", 24*time.Hour, "Open Graph tag cache expiration time")
+	ogCacheConsiderHost            = flag.Bool("og-cache-consider-host", false, "enable or disable the use of the host in the Open Graph tag cache")
+	extractResources               = flag.String("extract-resources", "", "if set, extract the static resources to the specified folder")
+	webmasterEmail                 = flag.String("webmaster-email", "", "if set, displays webmaster's email on the reject page for appeals")
+	versionFlag                    = flag.Bool("version", false, "print Anubis version")
+	publicUrl                      = flag.String("public-url", "", "the externally accessible URL for this Anubis instance, used for constructing redirect URLs (e.g., for forwardAuth).")
+	xffStripPrivate                = flag.Bool("xff-strip-private", true, "if set, strip private addresses from X-Forwarded-For")
+	customRealIPHeader             = flag.String("custom-real-ip-header", "", "if set, read remote IP from header of this name (in case your environment doesn't set X-Real-IP header)")
 
 	thothInsecure        = flag.Bool("thoth-insecure", false, "if set, connect to Thoth over plain HTTP/2, don't enable this unless support told you to")
 	thothURL             = flag.String("thoth-url", "", "if set, URL for Thoth, the IP reputation database for Anubis")
@@ -504,11 +506,21 @@ func main() {
 
 	if *useProxyProtocol {
 		srv.ConnContext = internal.ProxyProtoConnContext()
+		// This is pretty rudamentary, a better solution would be to have an object like [[[10.0.2.0/4, 192.168.178.20/32], IGNORE],[[10.0.2.0/4], USE]](same values just for demonstration) see https://github.com/pires/go-proxyproto/blob/eef9d7ef24f63315b173a5438e7b4c7849bc26b0/policy.go#L32
+		// also refactor into setupListener
 		var policyFunc proxyproto.PolicyFunc
-		policyFunc = proxyproto.MustStrictWhiteListPolicy(proxyProtocolAllowedCIDRsList)
+		switch *proxyProtocolPolicy {
+		case "IGNORE":
+			policyFunc = proxyproto.MustLaxWhiteListPolicy(proxyProtocolAllowedCIDRsList)
+		case "REJECT":
+			policyFunc = proxyproto.MustStrictWhiteListPolicy(proxyProtocolAllowedCIDRsList)
+		default:
+			log.Fatalf("invalid Proxy Protocol Policy: %s, valid values are IGNORE, REJECT", *proxyProtocolPolicy)
+		}
 		listener = &proxyproto.Listener{
-			Listener: listener,
-			Policy:   policyFunc,
+			Listener:          listener,
+			Policy:            policyFunc,
+			ReadHeaderTimeout: *proxyProtocolReadHeaderTimeout,
 		}
 	}
 

--- a/go.mod
+++ b/go.mod
@@ -146,6 +146,7 @@ require (
 	github.com/natefinch/atomic v1.0.1 // indirect
 	github.com/opencontainers/go-digest v1.0.0 // indirect
 	github.com/opencontainers/image-spec v1.1.1 // indirect
+	github.com/pires/go-proxyproto v0.8.1 // indirect
 	github.com/pjbgf/sha1cd v0.4.0 // indirect
 	github.com/pkg/errors v0.9.1 // indirect
 	github.com/pmezard/go-difflib v1.0.1-0.20181226105442-5d4384ee4fb2 // indirect

--- a/go.sum
+++ b/go.sum
@@ -328,6 +328,8 @@ github.com/opencontainers/go-digest v1.0.0 h1:apOUWs51W5PlhuyGyz9FCeeBIOUDA/6nW8
 github.com/opencontainers/go-digest v1.0.0/go.mod h1:0JzlMkj0TRzQZfJkVvzbP0HBR3IKzErnv2BNG4W4MAM=
 github.com/opencontainers/image-spec v1.1.1 h1:y0fUlFfIZhPF1W537XOLg0/fcx6zcHCJwooC2xJA040=
 github.com/opencontainers/image-spec v1.1.1/go.mod h1:qpqAh3Dmcf36wStyyWU+kCeDgrGnAve2nCC8+7h8Q0M=
+github.com/pires/go-proxyproto v0.8.1 h1:9KEixbdJfhrbtjpz/ZwCdWDD2Xem0NZ38qMYaASJgp0=
+github.com/pires/go-proxyproto v0.8.1/go.mod h1:ZKAAyp3cgy5Y5Mo4n9AlScrkCZwUy0g3Jf+slqQVcuU=
 github.com/pjbgf/sha1cd v0.4.0 h1:NXzbL1RvjTUi6kgYZCX3fPwwl27Q1LJndxtUDVfJGRY=
 github.com/pjbgf/sha1cd v0.4.0/go.mod h1:zQWigSxVmsHEZow5qaLtPYxpcKMMQpa09ixqBxuCS6A=
 github.com/pkg/errors v0.9.1 h1:FEBLx1zS214owpjy7qsBeixbURkuhQAwrK5UwLGTwt4=

--- a/internal/headers.go
+++ b/internal/headers.go
@@ -95,8 +95,10 @@ func ProxyProtocol(useProxyProtocol bool, sendProxyProtocol string, next http.Ha
 		}
 		// stolen from caddyserver :)
 		if sendProxyProtocol != "" {
+			// this will not work correctly because when we dont get the infromation via the proxy protocol headers but instead trough x-real-ip we never have a port for the address and always will set it to 0
 			address := r.Header.Get("X-Real-Ip")
 			addrPort, err := netip.ParseAddrPort(address)
+			//this check would only make sense if there would be a port
 			if err != nil {
 				// OK; probably didn't have a port
 				addr, err := netip.ParseAddr(address)

--- a/internal/proxyprotocol.go
+++ b/internal/proxyprotocol.go
@@ -1,0 +1,42 @@
+package internal
+
+import (
+	"context"
+	"net"
+
+	"github.com/pires/go-proxyproto"
+)
+
+type proxyProtocolUsedKey struct{}
+
+func ProxyProtocolUsed(ctx context.Context) bool {
+	v, ok := ctx.Value(proxyProtocolUsedKey{}).(bool)
+	return ok && v
+}
+
+type proxyProtocolHeaderKey struct{}
+
+func ProxyProtocolHeader(ctx context.Context) (proxyproto.Header, bool) {
+	v, ok := ctx.Value(proxyProtocolUsedKey{}).(proxyproto.Header)
+	return v, ok
+}
+
+func ProxyProtoConnContext() func(ctx context.Context, c net.Conn) context.Context {
+	return func(ctx context.Context, c net.Conn) context.Context {
+		ppConn, ok := c.(*proxyproto.Conn)
+		if !ok {
+			return ctx
+		}
+
+		hdr := ppConn.ProxyHeader()
+		if hdr == nil {
+			return context.WithValue(ctx, proxyProtocolUsedKey{}, false)
+		}
+
+		ctx = context.WithValue(ctx, proxyProtocolUsedKey{}, true)
+
+		ctx = context.WithValue(ctx, proxyProtocolHeaderKey{}, hdr)
+
+		return ctx
+	}
+}

--- a/internal/proxyprotocol.go
+++ b/internal/proxyprotocol.go
@@ -2,7 +2,9 @@ package internal
 
 import (
 	"context"
+	"fmt"
 	"net"
+	"net/netip"
 
 	"github.com/pires/go-proxyproto"
 )
@@ -21,6 +23,17 @@ func ProxyProtocolHeader(ctx context.Context) (*proxyproto.Header, bool) {
 	return h, ok
 }
 
+type proxyProtocolInfoKey struct{}
+
+func proxyProtocolInfo(ctx context.Context) (ProxyProtocolInfo, bool) {
+	h, ok := ctx.Value(proxyProtocolInfoKey{}).(ProxyProtocolInfo)
+	return h, ok
+}
+
+type ProxyProtocolInfo struct {
+	AddrPort netip.AddrPort
+}
+
 func ProxyProtoConnContext() func(ctx context.Context, c net.Conn) context.Context {
 	return func(ctx context.Context, c net.Conn) context.Context {
 		ppConn, ok := c.(*proxyproto.Conn)
@@ -37,5 +50,59 @@ func ProxyProtoConnContext() func(ctx context.Context, c net.Conn) context.Conte
 		ctx = context.WithValue(ctx, proxyProtocolHeaderKey{}, hdr)
 
 		return ctx
+	}
+}
+
+func SendProxyProtocolDialer(dialer *net.Dialer, proxyProtocolVersion string) func(ctx context.Context, network, addr string) (net.Conn, error) {
+	return func(ctx context.Context, network, addr string) (net.Conn, error) {
+		conn, err := dialer.DialContext(ctx, network, addr)
+		if err != nil {
+			return nil, fmt.Errorf("dial error: %w", err)
+		}
+		// stolen from caddyserver :)
+		proxyProtocolInfo, ok := proxyProtocolInfo(ctx)
+		if !ok {
+			return nil, fmt.Errorf("failed to get proxy protocol info from context")
+		}
+		var proxyv byte
+		switch proxyProtocolVersion {
+		case "v1":
+			proxyv = 1
+		case "v2":
+			proxyv = 2
+		default:
+			return nil, fmt.Errorf("unexpected proxy protocol version")
+		}
+
+		// The src and dst have to be of the same address family. As we don't know the original
+		// dst address (it's kind of impossible to know) and this address is generally of very
+		// little interest, we just set it to all zeros.
+		var destAddr net.Addr
+		switch {
+		case proxyProtocolInfo.AddrPort.Addr().Is4():
+			destAddr = &net.TCPAddr{
+				IP: net.IPv4zero,
+			}
+		case proxyProtocolInfo.AddrPort.Addr().Is6():
+			destAddr = &net.TCPAddr{
+				IP: net.IPv6zero,
+			}
+		default:
+			return nil, fmt.Errorf("unexpected remote addr type in proxy protocol info")
+		}
+		sourceAddr := &net.TCPAddr{
+			IP:   proxyProtocolInfo.AddrPort.Addr().AsSlice(),
+			Port: int(proxyProtocolInfo.AddrPort.Port()),
+			Zone: proxyProtocolInfo.AddrPort.Addr().Zone(),
+		}
+		header := proxyproto.HeaderProxyFromAddrs(proxyv, sourceAddr, destAddr)
+
+		_, err = header.WriteTo(conn)
+
+		if err != nil {
+			return nil, err
+		}
+
+		return conn, nil
 	}
 }

--- a/internal/proxyprotocol.go
+++ b/internal/proxyprotocol.go
@@ -38,7 +38,6 @@ func ProxyProtoConnContext() func(ctx context.Context, c net.Conn) context.Conte
 		ctx = context.WithValue(ctx, proxyProtocolHeaderKey{}, hdr)
 
 		v, ok := ctx.Value(proxyProtocolHeaderKey{}).(proxyproto.Header)
-		println(v.DestinationAddr)
 		return ctx
 	}
 }

--- a/internal/proxyprotocol.go
+++ b/internal/proxyprotocol.go
@@ -34,10 +34,8 @@ func ProxyProtoConnContext() func(ctx context.Context, c net.Conn) context.Conte
 		}
 
 		ctx = context.WithValue(ctx, proxyProtocolUsedKey{}, true)
-
 		ctx = context.WithValue(ctx, proxyProtocolHeaderKey{}, hdr)
 
-		v, ok := ctx.Value(proxyProtocolHeaderKey{}).(proxyproto.Header)
 		return ctx
 	}
 }

--- a/internal/proxyprotocol.go
+++ b/internal/proxyprotocol.go
@@ -16,9 +16,9 @@ func ProxyProtocolUsed(ctx context.Context) bool {
 
 type proxyProtocolHeaderKey struct{}
 
-func ProxyProtocolHeader(ctx context.Context) (proxyproto.Header, bool) {
-	v, ok := ctx.Value(proxyProtocolUsedKey{}).(proxyproto.Header)
-	return v, ok
+func ProxyProtocolHeader(ctx context.Context) (*proxyproto.Header, bool) {
+	h, ok := ctx.Value(proxyProtocolHeaderKey{}).(*proxyproto.Header)
+	return h, ok
 }
 
 func ProxyProtoConnContext() func(ctx context.Context, c net.Conn) context.Context {
@@ -37,6 +37,8 @@ func ProxyProtoConnContext() func(ctx context.Context, c net.Conn) context.Conte
 
 		ctx = context.WithValue(ctx, proxyProtocolHeaderKey{}, hdr)
 
+		v, ok := ctx.Value(proxyProtocolHeaderKey{}).(proxyproto.Header)
+		println(v.DestinationAddr)
 		return ctx
 	}
 }

--- a/lib/config.go
+++ b/lib/config.go
@@ -28,31 +28,33 @@ import (
 )
 
 type Options struct {
-	Next                     http.Handler
-	Policy                   *policy.ParsedConfig
-	Target                   string
-	TargetHost               string
-	TargetSNI                string
-	TargetInsecureSkipVerify bool
-	CookieDynamicDomain      bool
-	CookieDomain             string
-	CookieExpiration         time.Duration
-	CookiePartitioned        bool
-	BasePrefix               string
-	WebmasterEmail           string
-	RedirectDomains          []string
-	ED25519PrivateKey        ed25519.PrivateKey
-	HS512Secret              []byte
-	StripBasePrefix          bool
-	OpenGraph                config.OpenGraph
-	ServeRobotsTXT           bool
-	CookieSecure             bool
-	CookieSameSite           http.SameSite
-	Logger                   *slog.Logger
-	LogLevel                 string
-	PublicUrl                string
-	JWTRestrictionHeader     string
-	DifficultyInJWT          bool
+	Next                      http.Handler
+	Policy                    *policy.ParsedConfig
+	Target                    string
+	TargetHost                string
+	TargetSNI                 string
+	TargetInsecureSkipVerify  bool
+	CookieDynamicDomain       bool
+	CookieDomain              string
+	CookieExpiration          time.Duration
+	CookiePartitioned         bool
+	BasePrefix                string
+	WebmasterEmail            string
+	RedirectDomains           []string
+	ED25519PrivateKey         ed25519.PrivateKey
+	HS512Secret               []byte
+	StripBasePrefix           bool
+	OpenGraph                 config.OpenGraph
+	ServeRobotsTXT            bool
+	CookieSecure              bool
+	CookieSameSite            http.SameSite
+	Logger                    *slog.Logger
+	LogLevel                  string
+	PublicUrl                 string
+	JWTRestrictionHeader      string
+	DifficultyInJWT           bool
+	ProxyProtocolTimeout      time.Duration
+	ProxyProtocolAllowedCIDRs []string
 }
 
 func LoadPoliciesOrDefault(ctx context.Context, fname string, defaultDifficulty int, logLevel string) (*policy.ParsedConfig, error) {


### PR DESCRIPTION
resolves: #1208 

Allows listening to Connections with a Proxy Protocol Header(detects v1 or v2 automatically) and sets x-real-ip accordingly.

Theoretically this would allow to remove the usage of x-real-ip in caddy or ha proxy configs but only if all connections have a proxy header which can be configured with a combination of a "proxy-protocol-allowed-cidrs" and "proxy-protocol-policy".

Also allows sending Proxy Protocol Headers if "proxy-protocol-send-version" is set but it isnt possible to get the correct port if the connection didnt sent a proxy protocol header(eg use-proxy is false and we only have the x-real-ip from for example ha proxy)

Tests are missing as well as i want to get feedback on the implementation before i start, also could do a refactor of my code here and there

Here is a compose file which configured haproxy to send proxy protocol headers(i set ko.local when building the image via npm run container), creates a subnet with a cidr and allows this cidr to use proxy headers in anubis, if traffic comes from a different cidr it gets rejected also if the traffic wouldnt have proxy protocol header. 
One could change it when setting the policy to IGNORE but then x-real-ip has to be passed in from haproxy

``````

services:
  haproxy:
    image: haproxy:latest
    ports:
      - "80:80"
    configs:
      - source: haproxy_cfg
        target: /usr/local/etc/haproxy/haproxy.cfg
    networks:
      - anubis_subnet

  anubis:
    image: ko.local/anubis:latest
    pull_policy: if_not_present
    expose:
      - "3000"
    command:
      - --bind=:3000
      - --use-proxy-protocol=true
      - --proxy-protocol-allowed-cidrs=172.20.0.0/24
      - --proxy-protocol-policy=REJECT
      - --target=http://whoami:81
      - --slog-level=DEBUG
    networks:
      - anubis_subnet

  whoami:
    image: traefik/whoami
    pull_policy: always
    ports:
      - "81:81"
    environment:
      WHOAMI_PORT_NUMBER: 81
    networks:
      - anubis_subnet

configs:
  haproxy_cfg:
    content: |
      global
        log stdout format raw daemon

      defaults
          log global
          mode http
          option httplog
          timeout client 30s
          timeout connect 5s
          timeout server 30s
      
      frontend fe_http
          bind *:80
          default_backend be_anubis
      
      backend be_anubis
          mode http
          server anubis anubis:3000 send-proxy

networks:
  anubis_subnet:
    ipam:
      config:
        - subnet: 172.20.0.0/24
``````

Checklist:

- [ ] Added a description of the changes to the `[Unreleased]` section of docs/docs/CHANGELOG.md
- [ ] Added test cases to [the relevant parts of the codebase](https://anubis.techaro.lol/docs/developer/code-quality)
- [ ] Ran integration tests `npm run test:integration` (unsupported on Windows, please use WSL)
- [ ] All of my commits have [verified signatures](https://anubis.techaro.lol/docs/developer/signed-commits)
