### PR TITLE
Add IP mapped Perplexity user agents

### DIFF
--- a/data/clients/ai.yaml
+++ b/data/clients/ai.yaml
@@ -4,5 +4,5 @@
 #  - Claude-User: No published IP allowlist
 - name: "ai-clients"
   user_agent_regex: >-
-    ChatGPT-User|Claude-User|MistralAI-User
+    ChatGPT-User|Claude-User|MistralAI-User|Perplexity-User
   action: DENY

--- a/data/clients/perplexity-user.yaml
+++ b/data/clients/perplexity-user.yaml
@@ -1,0 +1,12 @@
+# Acts on behalf of user requests
+# https://docs.perplexity.ai/guides/bots
+- name: perplexity-user
+  user_agent_regex: Perplexity-User/.+; \+https\://perplexity\.ai/perplexity-user
+  action: ALLOW
+  # https://www.perplexity.com/perplexity-user.json
+  remote_addresses: [
+    "44.208.221.197/32",
+    "34.193.163.52/32",
+    "18.97.21.0/30",
+    "18.97.43.80/29",
+  ]

--- a/data/crawlers/ai-search.yaml
+++ b/data/crawlers/ai-search.yaml
@@ -4,5 +4,5 @@
 #  - Claude-SearchBot: No published IP allowlist
 - name: "ai-crawlers-search"
   user_agent_regex: >-
-    OAI-SearchBot|Claude-SearchBot
+    OAI-SearchBot|Claude-SearchBot|PerplexityBot
   action: DENY

--- a/data/crawlers/perplexitybot.yaml
+++ b/data/crawlers/perplexitybot.yaml
@@ -1,0 +1,16 @@
+# Indexing for search, does not collect training data
+# https://docs.perplexity.ai/guides/bots
+- name: perplexitybot
+  user_agent_regex: PerplexityBot/.+; \+https\://perplexity\.ai/perplexitybot
+  action: ALLOW
+  # https://www.perplexity.com/perplexitybot.json
+  remote_addresses: [
+    "107.20.236.150/32",
+    "3.224.62.45/32",
+    "18.210.92.235/32",
+    "3.222.232.239/32",
+    "3.211.124.183/32",
+    "3.231.139.107/32",
+    "18.97.1.228/30",
+    "18.97.9.96/29",
+  ]

--- a/data/meta/ai-block-moderate.yaml
+++ b/data/meta/ai-block-moderate.yaml
@@ -3,5 +3,7 @@
 - import: (data)/bots/ai-catchall.yaml
 - import: (data)/crawlers/ai-training.yaml
 - import: (data)/crawlers/openai-searchbot.yaml
+- import: (data)/crawlers/perplexitybot.yaml
 - import: (data)/clients/openai-chatgpt-user.yaml
 - import: (data)/clients/mistral-mistralai-user.yaml
+- import: (data)/clients/perplexity-user.yaml

--- a/data/meta/ai-block-permissive.yaml
+++ b/data/meta/ai-block-permissive.yaml
@@ -2,5 +2,7 @@
 - import: (data)/bots/ai-catchall.yaml
 - import: (data)/crawlers/openai-searchbot.yaml
 - import: (data)/crawlers/openai-gptbot.yaml
+- import: (data)/crawlers/perplexitybot.yaml
 - import: (data)/clients/openai-chatgpt-user.yaml
 - import: (data)/clients/mistral-mistralai-user.yaml
+- import: (data)/clients/perplexity-user.yaml


### PR DESCRIPTION
Perplexity has some proper documentation available for their crawlers, with published IP addresses: https://docs.perplexity.ai/guides/bots.

Looking at the documentation and the policies, there's no reason why Perplexity crawlers should be treated different than Claude's.

Not sure when Perplexity was initially added, if they had these published IP addresses at that point. There might be some context I'm not aware of.

Checklist:

- [x] Added a description of the changes to the `[Unreleased]` section of docs/docs/CHANGELOG.md
- [x] Added test cases to [the relevant parts of the codebase](https://anubis.techaro.lol/docs/developer/code-quality)
- [ ] Ran integration tests `npm run test:integration` (unsupported on Windows, please use WSL)
- [x] All of my commits have [verified signatures](https://anubis.techaro.lol/docs/developer/signed-commits)
