### PR TITLE
docs: clarify botstopper kubernetes instructions

### DIFF
--- a/docs/docs/admin/botstopper.mdx
+++ b/docs/docs/admin/botstopper.mdx
@@ -51,9 +51,8 @@ If you are using Kubernetes, you will need to create an image pull secret:
 kubectl create secret docker-registry \
   techarohq-botstopper \
   --docker-server ghcr.io \
-  --docker-username your-username \
-  --docker-password your-access-token \
-  --docker-email your@email.address
+  --docker-username any-username \
+  --docker-password <your-access-token> \
 ```
 
 Then attach it to your Deployment:


### PR DESCRIPTION
Purely a docs change:

This makes it clear that when generating a kubernetes secret to pull the bot stopper image that:
- no email is required
- a user is required but the actual value of the username is not checked
- the GH token needs to be pasted in

Checklist:

- [ ] Added a description of the changes to the `[Unreleased]` section of docs/docs/CHANGELOG.md (N/A)
- [ ] Added test cases to [the relevant parts of the codebase](https://anubis.techaro.lol/docs/developer/code-quality)  (N/A)
- [ ] Ran integration tests `npm run test:integration` (unsupported on Windows, please use WSL)  (N/A)
- [x] All of my commits have [verified signatures](https://anubis.techaro.lol/docs/developer/signed-commits)
