### PR TITLE
performance: remove significant overhead of decaymap/memory

### DIFF
--- a/decaymap/decaymap.go
+++ b/decaymap/decaymap.go
@@ -146,7 +146,7 @@ func (m *Impl[K, V]) Close() {
 func (m *Impl[K, V]) cleanupWorker() {
 	defer m.wg.Done()
 	batch := make([]deleteReq[K], 0, 64)
-	ticker := time.NewTicker(10 * time.Millisecond)
+	ticker := time.NewTicker(500 * time.Millisecond)
 	defer ticker.Stop()
 
 	flush := func() {

--- a/decaymap/decaymap_test.go
+++ b/decaymap/decaymap_test.go
@@ -32,7 +32,7 @@ func TestImpl(t *testing.T) {
 
 	// Deletion of expired entries after Get is deferred to a background worker.
 	// Assert it eventually disappears from the map.
-	deadline := time.Now().Add(200 * time.Millisecond)
+	deadline := time.Now().Add(700 * time.Millisecond)
 	for time.Now().Before(deadline) {
 		if dm.Len() == 0 {
 			break

--- a/docs/docs/CHANGELOG.md
+++ b/docs/docs/CHANGELOG.md
@@ -14,6 +14,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Add iplist2rule tool that lets admins turn an IP address blocklist into an Anubis ruleset.
 - Add Polish locale ([#1292](https://github.com/TecharoHQ/anubis/pull/1309))
 - Fix honeypot and imprint links missing `BASE_PREFIX` when deployed behind a path prefix ([#1402](https://github.com/TecharoHQ/anubis/issues/1402))
+- Improve idle performance in memory storage
 
 <!-- This changes the project to: -->
 


### PR DESCRIPTION
I have a significant base CPU load on an idle server due to mutex 100x per second.
Here is the flamegraph from production docker, sadly without debug symbols: https://flamegraph.com/share/fa374b5a-f7ad-11f0-8b19-cec02a92f1b8

Image from production docker. the upper line is Anubis WITHOUT any connected page right now, the other containers are handling work:
<img width="1108" height="438" alt="Bildschirmfoto vom 2026-01-22 18-47-51" src="https://github.com/user-attachments/assets/c49263cf-3e09-4e76-9d88-f38bbace132b" />


But while checking further, here the wall of strace futex:
```
[pid 1154482] nanosleep({tv_sec=0, tv_nsec=20000}, NULL) = 0
[pid 1154482] nanosleep({tv_sec=0, tv_nsec=20000},  <unfinished ...>
[pid 1154495] <... epoll_pwait resumed>[], 128, 1, NULL, 0) = 0
[pid 1154495] futex(0xc0000a1158, FUTEX_WAKE_PRIVATE, 1 <unfinished ...>
[pid 1154482] <... nanosleep resumed>NULL) = 0
[pid 1154495] <... futex resumed>)      = 1
[pid 1154493] <... futex resumed>)      = 0
[pid 1154482] nanosleep({tv_sec=0, tv_nsec=20000},  <unfinished ...>
[pid 1154495] epoll_pwait(4,  <unfinished ...>
[pid 1154493] epoll_pwait(4,  <unfinished ...>
[pid 1154495] <... epoll_pwait resumed>[], 128, 0, NULL, 0) = 0
[pid 1154495] futex(0xc0004e8958, FUTEX_WAIT_PRIVATE, 0, NULL <unfinished ...>
[pid 1154482] <... nanosleep resumed>NULL) = 0
[pid 1154482] futex(0x27bdfd0, FUTEX_WAIT_PRIVATE, 0, {tv_sec=0, tv_nsec=8249148} <unfinished ...>
[pid 1154493] <... epoll_pwait resumed>[], 128, 8, NULL, 0) = 0
[pid 1154493] epoll_pwait(4, [], 128, 0, NULL, 0) = 0
[pid 1154493] epoll_pwait(4,  <unfinished ...>
[pid 1154482] <... futex resumed>)      = -1 ETIMEDOUT (Connection timed out)
[pid 1154482] nanosleep({tv_sec=0, tv_nsec=20000}, NULL) = 0
[pid 1154482] nanosleep({tv_sec=0, tv_nsec=20000}, NULL) = 0
[pid 1154482] nanosleep({tv_sec=0, tv_nsec=20000}, NULL) = 0
```

Core wide it's related the decaymap for the memory storage which spawns 100 mutexes per second.

I doubt that a cleanup of expired items is needed that often, esp because the Get() function would remove expired one automatically.


While wring this I found this issue, which sounds verrrrry related: #1349


Checklist:

- [x] Added a description of the changes to the `[Unreleased]` section of docs/docs/CHANGELOG.md
- [ ] Added test cases to [the relevant parts of the codebase](https://anubis.techaro.lol/docs/developer/code-quality)
- [x] Ran integration tests `npm run test:integration` (unsupported on Windows, please use WSL)
- [x] All of my commits have [verified signatures](https://anubis.techaro.lol/docs/developer/signed-commits)
