### PR TITLE
Fix a CI warning: "The set-output command is deprecated"

### DIFF
--- a/cmd/containerbuild/main.go
+++ b/cmd/containerbuild/main.go
@@ -159,5 +159,8 @@ func run(command string) (string, error) {
 }
 
 func setOutput(key, val string) {
-	fmt.Printf("::set-output name=%s::%s\n", key, val)
+    github_output := os.Getenv("GITHUB_OUTPUT")
+    f, _ := os.OpenFile(github_output, os.O_WRONLY|os.O_APPEND|os.O_CREATE, 0644)
+    fmt.Fprintf(f, "%s=%s\n", key, val)
+    f.Close()
 }


### PR DESCRIPTION
CI currently throws deprecation warnings regarding the use of `set-output` [[recent example](https://github.com/TecharoHQ/anubis/actions/runs/21808470909)]:

> <img width="548" height="168" alt="image" src="https://github.com/user-attachments/assets/7147ccfc-8e1d-4992-b268-80caf9d20357" />

This PR updates the code where `set-output` is used, and migrates it to write to the `GITHUB_OUTPUT` file that is [now recommend](https://github.blog/changelog/2022-10-11-github-actions-deprecating-save-state-and-set-output-commands/).

Checklist:

- [ ] Added a description of the changes to the `[Unreleased]` section of docs/docs/CHANGELOG.md
- [ ] Added test cases to [the relevant parts of the codebase](https://anubis.techaro.lol/docs/developer/code-quality)
- [ ] Ran integration tests `npm run test:integration` (unsupported on Windows, please use WSL)
- [x] All of my commits have [verified signatures](https://anubis.techaro.lol/docs/developer/signed-commits)
