### PR TITLE
feat(docs): Add instructions on using Anubis with envoy-gateway

### DIFF
--- a/docs/docs/admin/environments/kubernetes.mdx
+++ b/docs/docs/admin/environments/kubernetes.mdx
@@ -130,3 +130,52 @@ Then point your Ingress to the Anubis port:
               # diff-add
               name: anubis
 ```
+
+## Envoy Gateway
+
+If you are using envoy-gateway, the `X-Real-Ip` header is not set by default, but Anubis does require it. You can resolve this by adding the header, either on the specific `HTTPRoute` where Anubis is listening, or on the `ClientTrafficPolicy` to apply it to any number of Gateways:
+
+HTTPRoute:
+```yaml
+apiVersion: gateway.networking.k8s.io/v1
+kind: HTTPRoute
+metadata:
+  name: app-route
+spec:
+  hostnames: ["app.domain.tld"]
+  parentRefs:
+    - name: envoy-external
+      namespace: network
+      sectionName: https
+  rules:
+    - backendRefs:
+        - identifier: *app
+          port: anubis
+      filters:
+        - type: RequestHeaderModifier
+          requestHeaderModifier:
+            set:
+              - name: X-Real-Ip
+                value: "%DOWNSTREAM_REMOTE_ADDRESS_WITHOUT_PORT%"
+```
+
+Applying to any number of Gateways:
+```yaml
+apiVersion: gateway.envoyproxy.io/v1alpha1
+kind: ClientTrafficPolicy
+metadata:
+  name: envoy
+spec:
+  headers:
+    earlyRequestHeaders:
+      set:
+        - name: X-Real-Ip
+          value: "%DOWNSTREAM_REMOTE_ADDRESS_WITHOUT_PORT%"
+  clientIPDetection:
+    xForwardedFor:
+      trustedCIDRs:
+        - 10.96.0.0/16 # Cluster pod CIDR
+  targetSelectors: # These will apply to all Gateways
+    - group: gateway.networking.k8s.io
+      kind: Gateway
+```


### PR DESCRIPTION
I spent [some time today](https://github.com/fhoekstra/home-ops/commits/main/?since=2026-02-16&until=2026-02-16) to get Anubis to work with envoy-gateway, given the upcoming nginx-ingress EOL, so I figured I'd document this for other users. Not sure how other Gateway API implementations compare to this.

Checklist:

- [ ] Added a description of the changes to the `[Unreleased]` section of docs/docs/CHANGELOG.md
- [ ] Added test cases to [the relevant parts of the codebase](https://anubis.techaro.lol/docs/developer/code-quality)
- [ ] Ran integration tests `npm run test:integration` (unsupported on Windows, please use WSL)
- [x] All of my commits have [verified signatures](https://anubis.techaro.lol/docs/developer/signed-commits)
