### PR TITLE
docs(admin/policy): document ReadWritePaths for logging to files

### DIFF
--- a/docs/docs/admin/policies.mdx
+++ b/docs/docs/admin/policies.mdx
@@ -393,6 +393,32 @@ logging:
 
 When files are rotated out, the old files will be named after the rotation timestamp in [RFC 3339 format](https://www.rfc-editor.org/rfc/rfc3339).
 
+:::note
+
+If you are running Anubis in systemd via a native package, the default systemd unit settings are very restrictive and will forbid writing to folders in `/var/log`. In order to fix this, please make a [drop-in unit](https://www.flatcar.org/docs/latest/setup/systemd/drop-in-units/) like the following:
+
+```text
+# /etc/systemd/anubis@instance-name.service.d/50-var-log-readwrite.conf
+[Service]
+ReadWritePaths=/run /var/log/anubis
+```
+
+Once you write this to the correct place, reload the systemd configuration:
+
+```text
+sudo systemctl daemon-reload
+```
+
+And then restart Anubis:
+
+```text
+sudo systemctl restart anubis@instance-name
+```
+
+You may be required to make drop-ins for each Anubis instance depending on the facts and circumstances of your deployment.
+
+:::
+
 ### `stdio` sink
 
 By default, Anubis logs everything to the standard error stream of its process. This requires no configuration:


### PR DESCRIPTION
The default Anubis systemd configuration is very restrictive in order to prevent any possible compromise of Anubis to be useful by threat actors. As such, it assumes all logs will be pushed to the system journal. Some administrators do not want Anubis' logs to be pushed to the system journal and want Anubis to log to a file instead.

This change documents how to set up ReadWritePaths in the Anubis systemd configuration such that Anubis can lot to a file as administrators expect.

Closes: #1468

<!--
delete me and describe your change here, give enough context for a maintainer to understand what and why

See https://anubis.techaro.lol/docs/developer/code-quality for more information
-->

Checklist:

- [ ] Added a description of the changes to the `[Unreleased]` section of docs/docs/CHANGELOG.md
- [ ] Added test cases to [the relevant parts of the codebase](https://anubis.techaro.lol/docs/developer/code-quality)
- [ ] Ran integration tests `npm run test:integration` (unsupported on Windows, please use WSL)
- [x] All of my commits have [verified signatures](https://anubis.techaro.lol/docs/developer/signed-commits)
