### PR TITLE
docs: fix mixed tab/space indentation in Caddy config example

### DIFF
--- a/docs/docs/CHANGELOG.md
+++ b/docs/docs/CHANGELOG.md
@@ -11,6 +11,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+- Fixed mixed tab/space indentation in Caddy documentation code block
+
 <!-- This changes the project to: -->
 
 ## v1.25.0: Necron

--- a/docs/docs/admin/environments/caddy.mdx
+++ b/docs/docs/admin/environments/caddy.mdx
@@ -62,9 +62,9 @@ yourdomain.example.com {
   tls your@email.address
 
   reverse_proxy http://anubis:3000 {
-		header_up X-Real-Ip {remote_host}
-		header_up X-Http-Version {http.request.proto}
-	}
+    header_up X-Real-Ip {remote_host}
+    header_up X-Http-Version {http.request.proto}
+  }
 }
 ```
 


### PR DESCRIPTION
Hi.

Screenshot:

<img width="300" alt="image" src="https://github.com/user-attachments/assets/f661f7bc-097b-4361-b83b-05189e3f814f" />


Checklist:

- [x] Added a description of the changes to the `[Unreleased]` section of docs/docs/CHANGELOG.md
- [ ] Added test cases to [the relevant parts of the codebase](https://anubis.techaro.lol/docs/developer/code-quality)
- [ ] Ran integration tests `npm run test:integration` (unsupported on Windows, please use WSL)
- [x] All of my commits have [verified signatures](https://anubis.techaro.lol/docs/developer/signed-commits)
