### PR TITLE
feat(data): add Citoid to good bots list

### DIFF
--- a/.github/actions/spelling/allow.txt
+++ b/.github/actions/spelling/allow.txt
@@ -31,3 +31,5 @@ Stargate
 FFXIV
 uvensys
 de
+envoyproxy
+unipromos

--- a/data/crawlers/_allow-good.yaml
+++ b/data/crawlers/_allow-good.yaml
@@ -8,4 +8,5 @@
 - import: (data)/crawlers/marginalia.yaml
 - import: (data)/crawlers/mojeekbot.yaml
 - import: (data)/crawlers/commoncrawl.yaml
+- import: (data)/crawlers/wikimedia-citoid.yaml
 - import: (data)/crawlers/yandexbot.yaml

--- a/data/crawlers/wikimedia-citoid.yaml
+++ b/data/crawlers/wikimedia-citoid.yaml
@@ -1,0 +1,18 @@
+# Wikimedia Foundation citation services
+# https://www.mediawiki.org/wiki/Citoid
+
+- name: wikimedia-citoid
+  user_agent_regex: "Citoid/WMF"
+  action: ALLOW
+  remote_addresses: [
+    "208.80.152.0/22",
+    "2620:0:860::/46",
+  ]
+
+- name: wikimedia-zotero-translation-server
+  user_agent_regex: "ZoteroTranslationServer/WMF"
+  action: ALLOW
+  remote_addresses: [
+    "208.80.152.0/22",
+    "2620:0:860::/46",
+  ]


### PR DESCRIPTION
Wikimedia Foundation runs a service called citoid which retrieves citation metadata from urls in order to create formatted citations. This is primarily for adding citations to Wikipedia but is used by other services as well. https://www.mediawiki.org/wiki/Citoid

This contains the relevant allocated IP range (https://wikitech.wikimedia.org/wiki/IP_and_AS_allocations) and user-agent for the two services we use to generate the citation metadata (citoid makes HEAD requests to do some sanity checking and also GET occasionally if zotero fails, zotero does most of the GET requests.)




