### PR TITLE
feat(data): allow Software Heritage IP addresses

### DIFF
--- a/data/crawlers/_allow-good.yaml
+++ b/data/crawlers/_allow-good.yaml
@@ -8,5 +8,6 @@
 - import: (data)/crawlers/marginalia.yaml
 - import: (data)/crawlers/mojeekbot.yaml
 - import: (data)/crawlers/commoncrawl.yaml
+- import: (data)/crawlers/software-heritage.yaml
 - import: (data)/crawlers/wikimedia-citoid.yaml
 - import: (data)/crawlers/yandexbot.yaml

--- a/data/crawlers/software-heritage.yaml
+++ b/data/crawlers/software-heritage.yaml
@@ -1,0 +1,4 @@
+- name: software-heritage
+  action: ALLOW
+  # https://docs.softwareheritage.org/user/faq/#which-ip-address-range-should-we-mark-as-safe-in-our-anti-bot-protection-systems
+  remote_addresses: [ "128.93.166.0/26" ]

--- a/docs/docs/CHANGELOG.md
+++ b/docs/docs/CHANGELOG.md
@@ -11,6 +11,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+- Allow requests from Software Heritage
 - Expose [pprof endpoints](https://pkg.go.dev/net/http/pprof) on the metrics listener to enable profiling Anubis in production.
 - fix: prevent nil pointer panic in challenge validation when threshold rules match during PassChallenge (#1463)
 - Instruct reverse proxies to not cache error pages.


### PR DESCRIPTION
Software Heritage is similar to the Internet Archive (which is allowed) but is focused on archiving source code from forges instead of pages from websites.
    
Software Heritage processes do not use generic web crawling, but instead forge-specific and VCS-specific tools that are designed to use as little resources as possible, especially using incremental pulls, using/adding APIs and ignoring repositories that have not changed.

https://github.com/TecharoHQ/anubis/pulls/276
https://www.softwareheritage.org/
https://www.softwareheritage.org/software-heritage-faq/
https://docs.softwareheritage.org/user/faq/
https://gitlab.softwareheritage.org/swh
https://gitlab.softwareheritage.org/swh/infra/add-forge-now-requests/-/merge_requests/4

Disclosure: I am currently a contractor with Software Heritage.

Checklist:

- [x] Added a description of the changes to the `[Unreleased]` section of docs/docs/CHANGELOG.md
- [x] Added test cases to [the relevant parts of the codebase](https://github.com/TecharoHQ/anubis/blob/main/CONTRIBUTING.md)
- [x] Ran integration tests `npm run test:integration` (unsupported on Windows, please use WSL)
- [x] All of my commits have [verified signatures](https://anubis.techaro.lol/docs/developer/signed-commits)
