### PR TITLE
feat(api): add public APIs for headers

### DIFF
--- a/lib/anubis.go
+++ b/lib/anubis.go
@@ -672,3 +672,25 @@ func (s *Server) check(r *http.Request, lg *slog.Logger) (policy.CheckResult, *p
 		Rules: &checker.List{},
 	}, nil
 }
+
+// ADDED FOR PUBLIC USE
+
+func AddCustomRealIPHeader(customRealIPHeaderValue string, next http.Handler) http.Handler {
+	return internal.CustomRealIPHeader(customRealIPHeaderValue, next)
+}
+
+func AddRemoteXRealIP(useRemoteAddress bool, bindNetwork string, next http.Handler) http.Handler {
+	return internal.RemoteXRealIP(useRemoteAddress, bindNetwork, next)
+}
+
+func AddXForwardedForToXRealIP(next http.Handler) http.Handler {
+	return internal.XForwardedForToXRealIP(next)
+}
+
+func AddXForwardedForUpdate(stripPrivate bool, next http.Handler) http.Handler {
+	return internal.XForwardedForUpdate(stripPrivate, next)
+}
+
+func AddJA4H(next http.Handler) http.Handler {
+	return internal.JA4H(next)
+}


### PR DESCRIPTION
This is a small change, which adds public APIs for the same request header methods used under the hood by the standard CLI server.

This was done for [my PR to zoraxy adding native Anubis support](https://github.com/tobychui/zoraxy/pull/1122).

(Note: I only noticed I had to sign my commits after I made the initial one, so I redid it with a new signed commit and force-pushed. Hopefully that works.)

Checklist:

- [ ] Added a description of the changes to the `[Unreleased]` section of docs/docs/CHANGELOG.md
- [ ] Added test cases to [the relevant parts of the codebase](https://github.com/TecharoHQ/anubis/blob/main/CONTRIBUTING.md)
- [ ] Ran integration tests `npm run test:integration` (unsupported on Windows, please use WSL)
- [x] All of my commits have [verified signatures](https://anubis.techaro.lol/docs/developer/signed-commits)
