### PR TITLE
fix(honeypot): remove DoS vector

### DIFF
--- a/docs/docs/CHANGELOG.md
+++ b/docs/docs/CHANGELOG.md
@@ -23,6 +23,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Fix CEL internal errors when iterating `headers`/`query` map wrappers by implementing map iterators for `HTTPHeaders` and `URLValues` ([#1465](https://github.com/TecharoHQ/anubis/pull/1465)).
 - Enable [metrics serving via TLS](./admin/policies.mdx#tls), including [mutual TLS (mTLS)](./admin/policies.mdx#mtls).
 - Enable [HTTP basic auth](./admin/policies.mdx#http-basic-authentication) for the metrics server.
+- Fix a bug in the dataset poisoning maze that could allow denial of service [#1580](https://github.com/TecharoHQ/anubis/issues/1580).
 
 ## v1.25.0: Necron
 

--- a/internal/honeypot/naive/naive.go
+++ b/internal/honeypot/naive/naive.go
@@ -76,13 +76,6 @@ type Impl struct {
 	affirmation, body, title spintax.Spintax
 }
 
-func (i *Impl) incrementUA(ctx context.Context, userAgent string) int {
-	result, _ := i.uaWeight.Get(ctx, internal.SHA256sum(userAgent))
-	result++
-	i.uaWeight.Set(ctx, internal.SHA256sum(userAgent), result, time.Hour)
-	return result
-}
-
 func (i *Impl) incrementNetwork(ctx context.Context, network string) int {
 	result, _ := i.networkWeight.Get(ctx, internal.SHA256sum(network))
 	result++
@@ -90,20 +83,19 @@ func (i *Impl) incrementNetwork(ctx context.Context, network string) int {
 	return result
 }
 
-func (i *Impl) CheckUA() checker.Impl {
-	return checker.Func(func(r *http.Request) (bool, error) {
-		result, _ := i.uaWeight.Get(r.Context(), internal.SHA256sum(r.UserAgent()))
-		if result >= 25 {
-			return true, nil
-		}
-
-		return false, nil
-	})
-}
-
 func (i *Impl) CheckNetwork() checker.Impl {
 	return checker.Func(func(r *http.Request) (bool, error) {
-		result, _ := i.uaWeight.Get(r.Context(), internal.SHA256sum(r.UserAgent()))
+		realIP, _ := internal.RealIP(r)
+		if !realIP.IsValid() {
+			realIP = netip.MustParseAddr(r.Header.Get("X-Real-Ip"))
+		}
+
+		network, ok := internal.ClampIP(realIP)
+		if !ok {
+			return false, nil
+		}
+
+		result, _ := i.networkWeight.Get(r.Context(), internal.SHA256sum(network.String()))
 		if result >= 25 {
 			return true, nil
 		}
@@ -164,7 +156,6 @@ func (i *Impl) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 	}
 
 	networkCount := i.incrementNetwork(r.Context(), network.String())
-	uaCount := i.incrementUA(r.Context(), r.UserAgent())
 
 	stage := r.PathValue("stage")
 
@@ -172,8 +163,8 @@ func (i *Impl) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 		lg.Debug("found new entrance point", "id", id, "stage", stage, "userAgent", r.UserAgent(), "clampedIP", network)
 	} else {
 		switch {
-		case networkCount%256 == 0, uaCount%256 == 0:
-			lg.Warn("found possible crawler", "id", id, "network", network)
+		case networkCount%256 == 0:
+			lg.Warn("found possible crawler", "id", id, "network", network, "userAgent", r.UserAgent())
 		}
 	}
 

--- a/lib/config.go
+++ b/lib/config.go
@@ -190,14 +190,6 @@ func New(opts Options) (*Server, error) {
 				},
 				Name: "honeypot/network",
 			},
-			policy.Bot{
-				Rules:  mazeGen.CheckUA(),
-				Action: config.RuleWeigh,
-				Weight: &config.Weight{
-					Adjust: 30,
-				},
-				Name: "honeypot/user-agent",
-			},
 		)
 	} else {
 		result.logger.Error("can't init honeypot subsystem", "err", err)


### PR DESCRIPTION
Using the User-Agent as a filtering vector for the honeypot maze was a decent idea, however in practice it can become a DoS vector by a malicious client adding a lot of points to Google Chrome's User-Agent string. In practice it also seems that the worst offenders use vanilla Google Chrome User-Agent strings as well, meaning that this backfires horribly.

Gotta crack a few eggs to make omlettes.

Closes: #1580

<!--
delete me and describe your change here, give enough context for a maintainer to understand what and why

See https://github.com/TecharoHQ/anubis/blob/main/CONTRIBUTING.md for more information
-->

Checklist:

- [x] Added a description of the changes to the `[Unreleased]` section of docs/docs/CHANGELOG.md
- [ ] Added test cases to [the relevant parts of the codebase](https://github.com/TecharoHQ/anubis/blob/main/CONTRIBUTING.md)
- [x] Ran integration tests `npm run test:integration` (unsupported on Windows, please use WSL)
- [x] All of my commits have [verified signatures](https://anubis.techaro.lol/docs/developer/signed-commits)
