### PR TITLE
fix(Makefile): use `$(CURDIR)` instead of `$(PWD)` so `make -C` works

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -10,7 +10,7 @@ deps:
 	$(NPM) ci
 	$(GO) mod download
 
-assets: PATH:=$(PWD)/node_modules/.bin:$(PATH)
+assets: PATH:=$(CURDIR)/node_modules/.bin:$(PATH)
 assets: deps
 	$(GO) generate ./...
 	./web/build.sh

--- a/docs/docs/CHANGELOG.md
+++ b/docs/docs/CHANGELOG.md
@@ -25,6 +25,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Enable [metrics serving via TLS](./admin/policies.mdx#tls), including [mutual TLS (mTLS)](./admin/policies.mdx#mtls).
 - Enable [HTTP basic auth](./admin/policies.mdx#http-basic-authentication) for the metrics server.
 - Fix a bug in the dataset poisoning maze that could allow denial of service [#1580](https://github.com/TecharoHQ/anubis/issues/1580).
+- fix(Makefile): use `$(CURDIR)` instead of `$(PWD)` in the `assets` target so `make -C anubis assets` works from a parent directory.
 
 ## v1.25.0: Necron
 


### PR DESCRIPTION
Hi 👋 

First time contributor here, hope I managed to follow the guidelines.

## Issue

`$(PWD)` is the shell environment variable, untouched by Make's `-C` flag. `$(CURDIR)` is Make's own absolute-path variable for the directory it's processing.

## Reproducer

```sh
mkdir parent && cd parent
git clone https://github.com/TecharoHQ/anubis
cd .. && make -C parent/anubis assets
# fails: ./xess/build.sh: line 6: postcss: command not found
```

`PATH` ends up pointing at `parent/node_modules/.bin` (which doesn't exist) rather than `parent/anubis/node_modules/.bin`. With `$(CURDIR)`, the same invocation succeeds.

## Context

Noticed this while building a Caddy plugin against `libanubis`: my project's `Makefile` wanted to invoke `make -C $(ANUBIS_DIR) assets` to drive the asset build.

Workaround was `cd $(ANUBIS_DIR) && $(MAKE) assets`, but `$(CURDIR)` is the right fix and lets `-C` work in general.

Checklist:

- [x] Added a description of the changes to the `[Unreleased]` section of `docs/docs/CHANGELOG.md`
- [ ] Added test cases — n/a, minor Makefile fix; pre-commit hook ran the full unit-test suite (passed)
- [x] Ran integration tests — _partial_ ⚠️ 
  - chromium + firefox pass; 
  - webkit fails with `Frame.Goto http://[::]:59395: playwright: bad URL` on every test (env/playwright-webkit issue parsing IPv6 unspecified-address URLs, unrelated to this `Makefile` change
- [x] All of my commits have verified signatures
