### PR TITLE
fix(lib): default `CookieExpiration` to `CookieDefaultExpirationTime` when zero

### DIFF
--- a/docs/docs/CHANGELOG.md
+++ b/docs/docs/CHANGELOG.md
@@ -25,6 +25,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Enable [metrics serving via TLS](./admin/policies.mdx#tls), including [mutual TLS (mTLS)](./admin/policies.mdx#mtls).
 - Enable [HTTP basic auth](./admin/policies.mdx#http-basic-authentication) for the metrics server.
 - Fix a bug in the dataset poisoning maze that could allow denial of service [#1580](https://github.com/TecharoHQ/anubis/issues/1580).
+- fix(lib): apply `anubis.CookieDefaultExpirationTime` when `Options.CookieExpiration` is left at the zero value, so library consumers don't issue expired-on-arrival cookies. The Anubis CLI was unaffected because `--cookie-expiration-time` carries its own default.
 
 ## v1.25.0: Necron
 

--- a/lib/anubis_test.go
+++ b/lib/anubis_test.go
@@ -279,6 +279,54 @@ func TestCVE2025_24369(t *testing.T) {
 	}
 }
 
+// TestCookieDefaultExpirationFilled verifies that lib.New() fills
+// opts.CookieExpiration with anubis.CookieDefaultExpirationTime when the
+// caller leaves it at the zero value. Without this default, the cookie's
+// Expires attribute and the JWT's exp claim are both set to time.Now(),
+// producing an expired-on-arrival cookie that triggers an infinite
+// challenge loop on the next request.
+//
+// The Anubis CLI sidesteps this via the --cookie-expiration-time flag's
+// default value, but library consumers (e.g. plugins for other web
+// servers) that construct Options directly hit the zero-value bug.
+func TestCookieDefaultExpirationFilled(t *testing.T) {
+	pol := loadPolicies(t, "testdata/zero_difficulty.yaml", 0)
+
+	srv := spawnAnubis(t, Options{
+		Next:   http.NewServeMux(),
+		Policy: pol,
+		// CookieExpiration intentionally left unset (zero value).
+	})
+
+	if got, want := srv.opts.CookieExpiration, anubis.CookieDefaultExpirationTime; got != want {
+		t.Fatalf("opts.CookieExpiration default not applied: got %v, want %v", got, want)
+	}
+
+	// End-to-end sanity check: the cookie issued after a successful
+	// challenge has an Expires attribute well in the future, not now-ish.
+	ts := httptest.NewServer(internal.RemoteXRealIP(true, "tcp", srv))
+	defer ts.Close()
+
+	cli := httpClient(t)
+	chall := makeChallenge(t, ts, cli)
+	resp := handleChallengeZeroDifficulty(t, ts, cli, chall)
+
+	var ckie *http.Cookie
+	for _, c := range resp.Cookies() {
+		if c.Name == anubis.CookieName {
+			ckie = c
+			break
+		}
+	}
+	if ckie == nil {
+		t.Fatalf("cookie %q not found in PassChallenge response", anubis.CookieName)
+	}
+	// Tolerate some clock skew; we just want to confirm it's not "now".
+	if !ckie.Expires.After(time.Now().Add(time.Hour)) {
+		t.Errorf("cookie Expires=%v should be ~7d in the future, not now-ish", ckie.Expires)
+	}
+}
+
 func TestCookieCustomExpiration(t *testing.T) {
 	pol := loadPolicies(t, "testdata/zero_difficulty.yaml", 0)
 	ckieExpiration := 10 * time.Minute

--- a/lib/config.go
+++ b/lib/config.go
@@ -112,6 +112,15 @@ func New(opts Options) (*Server, error) {
 		opts.ED25519PrivateKey = priv
 	}
 
+	// Without a default, the zero value (0) flows into both the cookie's
+	// Expires attribute and the JWT's exp claim, producing
+	// expired-on-arrival cookies and an infinite challenge loop. The
+	// Anubis CLI fills this via a flag default; library consumers that
+	// construct Options directly need this fallback in lib.New().
+	if opts.CookieExpiration == 0 {
+		opts.CookieExpiration = anubis.CookieDefaultExpirationTime
+	}
+
 	anubis.BasePrefix = strings.TrimRight(opts.BasePrefix, "/")
 	anubis.PublicUrl = opts.PublicUrl
 


### PR DESCRIPTION
`Options.CookieExpiration time.Duration` has a zero value of `0`. When left unset, both the cookie's `Expires` attribute and the JWT's `exp` claim are computed as `time.Now().Add(0)` = now:

```go
// lib/http.go SetCookie:
Expires: time.Now().Add(cookieOpts.Expiry)
// cookieOpts.Expiry falls back to s.opts.CookieExpiration when zero
```

```go
// lib/anubis.go signJWT:
claims["exp"] = time.Now().Add(s.opts.CookieExpiration).Unix()
```

Result: browser solves PoW, libanubis issues an expired-on-arrival cookie, browser re-requests, libanubis sees no valid cookie, serves the challenge again. **Infinite loop.**

The Anubis CLI sidesteps this because `--cookie-expiration-time` (added in #389) carries its own default of `anubis.CookieDefaultExpirationTime` (7 days). Library consumers that construct `Options` directly — for example, plugins for other web servers — hit the zero-value bug.

This change applies the same default in `lib.New()` so the library has the same safe behavior as the CLI.

## Test

`TestCookieDefaultExpirationFilled` verifies:

1. `srv.opts.CookieExpiration` is filled to `anubis.CookieDefaultExpirationTime` after `New()` when the caller leaves it unset.
2. End-to-end: the cookie issued by `PassChallenge` has its `Expires` attribute well in the future, not "now-ish".

## Context

I noticed this while building a Caddy plugin against `libanubis`. Browser successfully solved the PoW but kept looping back to the challenge page. Workaround was to set `CookieExpiration: anubis.CookieDefaultExpirationTime` explicitly in the consumer; the proper fix is here, in the library.

Checklist:

- [x] Added a description of the changes to the `[Unreleased]` section of `docs/docs/CHANGELOG.md`
- [x] Added test cases to the relevant parts of the codebase (`TestCookieDefaultExpirationFilled` in `lib/anubis_test.go`)
- [ ] Ran integration tests `npm run test:integration` — _partial_ ⚠️ 
   - chromium + firefox pass
   - webkit fails with `Frame.Goto http://[::]:port: playwright: bad URL` on every test, pre-existing env/playwright-webkit issue parsing IPv6 unspecified-address URLs (also seen on `main`)
- [x] All of my commits have verified signatures
