### PR TITLE
feat(web): waste headless chrome bandwidth

### DIFF
--- a/docs/docs/CHANGELOG.md
+++ b/docs/docs/CHANGELOG.md
@@ -24,9 +24,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Fix CEL internal errors when iterating `headers`/`query` map wrappers by implementing map iterators for `HTTPHeaders` and `URLValues` ([#1465](https://github.com/TecharoHQ/anubis/pull/1465)).
 - Enable [metrics serving via TLS](./admin/policies.mdx#tls), including [mutual TLS (mTLS)](./admin/policies.mdx#mtls).
 - Enable [HTTP basic auth](./admin/policies.mdx#http-basic-authentication) for the metrics server.
-- Fix a bug in the dataset poisoning maze that could allow denial of service [#1580](https://github.com/TecharoHQ/anubis/issues/1580).
+- Fix a bug in the dataset poisoning maze that could allow denial of service .[#1580](https://github.com/TecharoHQ/anubis/issues/1580).
 - Add config option to add ASN to logs/metrics.
-- Log weight when issuing challenge
+- Log weight when issuing challenge.
+- Waste bandwidth for headless chrome using the [Prompt API](https://developer.chrome.com/docs/ai/prompt-api).
 
 ## v1.25.0: Necron
 

--- a/web/js/main.ts
+++ b/web/js/main.ts
@@ -93,11 +93,30 @@ const initTranslations = async () => {
   translations = await loadTranslations(currentLang);
 };
 
+const wasteHeadlessChromeDisk = async () => {
+  if (window.LanguageModel !== undefined) {
+    const session = await window.LanguageModel.create({
+      initialPrompts: [
+        {
+          role: "system",
+          content: "You are a helpful assistant that responds in as many words as possible. Be verbose and answer questions fully with as much detail as possible."
+        },
+        {
+          role: "user",
+          content: "Why is the sky blue?",
+        },
+      ],
+    })
+  }
+};
+
 const t = (key) => translations[`js_${key}`] || translations[key] || key;
 
 (async () => {
   // Initialize translations first
   await initTranslations();
+
+  wasteHeadlessChromeDisk();
 
   const dependencies = [
     {


### PR DESCRIPTION
Most of the worst of the worst scrapers run Headless Chrome. Headless Chrome is difficult for Anubis to combat because it follows all the rules that browsers do. The worst of the worst scrapers also use residential proxy services. Those residental proxy services charge upwards of $1 per GB of data egressed or ingressed. The Prompt API makes Chrome download a 4Gi or 16Gi machine learning model. When you ask it to start downloading, it will _continue_ downloading even when you leave the Anubis challenge page.

This will make the local model answer "why is the sky blue?" in an absurt amount of detail, which wastes both bandwidth and scraper CPU (some scraping companies charge via Chrome CPU too).

<!--
delete me and describe your change here, give enough context for a maintainer to understand what and why

See https://github.com/TecharoHQ/anubis/blob/main/CONTRIBUTING.md for more information
-->

Checklist:

- [x] Added a description of the changes to the `[Unreleased]` section of docs/docs/CHANGELOG.md
- [ ] Added test cases to [the relevant parts of the codebase](https://github.com/TecharoHQ/anubis/blob/main/CONTRIBUTING.md)
- [x] Ran integration tests `npm run test:integration` (unsupported on Windows, please use WSL)
- [x] All of my commits have [verified signatures](https://anubis.techaro.lol/docs/developer/signed-commits)
