### PR TITLE
docs(admin/environments): change apache remoteip proxy header

### DIFF
--- a/docs/docs/admin/environments/apache.mdx
+++ b/docs/docs/admin/environments/apache.mdx
@@ -96,7 +96,7 @@ Assuming you are protecting `anubistest.techaro.lol`, you need the following ser
        # Pass the remote IP to the proxied application instead of 127.0.0.1
        # This requires mod_remoteip
        RemoteIPHeader X-Real-IP
-       RemoteIPTrustedProxy 127.0.0.1/32
+       RemoteIPInternalProxy 127.0.0.1/32
 </VirtualHost>
 ```
 


### PR DESCRIPTION
RemoteIPTrustedProxy does not work for private IP addresses, so should use RemoteIPInternalProxy

Checklist:

- [ ] Added a description of the changes to the `[Unreleased]` section of docs/docs/CHANGELOG.md
- [ ] Added test cases to [the relevant parts of the codebase](https://github.com/TecharoHQ/anubis/blob/main/CONTRIBUTING.md)
- [ ] Ran integration tests `npm run test:integration` (unsupported on Windows, please use WSL)
- [x] All of my commits have [verified signatures](https://anubis.techaro.lol/docs/developer/signed-commits)
