### PR TITLE
fix(honeypot/naive): apply robot9001 style delays

### DIFF
--- a/docs/docs/CHANGELOG.md
+++ b/docs/docs/CHANGELOG.md
@@ -14,6 +14,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 <!-- This changes the project to: -->
 
 - Patch [GHSA-6wcg-mqvh-fcvg](https://github.com/TecharoHQ/anubis/security/advisories/GHSA-6wcg-mqvh-fcvg) by containing subrequest logic to Anubis instances in subrequest mode.
+- Implement robot9001 style delays on the honeypot feature so that the first hit takes 1 millisecond, the second takes 2, etc.
 - Move metrics server configuration to [the policy file](./admin/policies.mdx#metrics-server).
 - Expose [pprof endpoints](https://pkg.go.dev/net/http/pprof) on the metrics listener to enable profiling Anubis in production.
 - fix: prevent nil pointer panic in challenge validation when threshold rules match during PassChallenge (#1463)

--- a/internal/honeypot/naive/naive.go
+++ b/internal/honeypot/naive/naive.go
@@ -5,6 +5,7 @@ import (
 	_ "embed"
 	"fmt"
 	"log/slog"
+	"math"
 	"math/rand/v2"
 	"net/http"
 	"net/netip"
@@ -167,6 +168,9 @@ func (i *Impl) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 			lg.Warn("found possible crawler", "id", id, "network", network, "userAgent", r.UserAgent())
 		}
 	}
+
+	millisecondAmount := math.Pow(float64(networkCount), 2)
+	time.Sleep(time.Duration(millisecondAmount) * time.Millisecond)
 
 	spins := i.makeSpins()
 	affirmations := i.makeAffirmations()


### PR DESCRIPTION
Currently the honeypotting feature has no limits or delays anywhere and uses that to feed an internal greylist of IP networks. This can cause issues such as in #1613 where Claude's crawler seemed to pick up on it and egress data at over one megabit per second until the administrator noticed and blocked the address range.

This takes a different approach by inspiration of how the classic #xkcd IRC bot Robot9000 works. The first time a given IPv4 /24 or IPv6 /48 visits a honepot page, Anubis sleeps for 1 millisecond. The second it sleeps for two milliseconds. The third is four milliseconds and so on. The goal of this is to make the scraping inherently self-limiting such that the scrapers go off in their own corner where they won't really hurt anyone.

Let's see if this works out according to keikaku.

Ref: https://github.com/TecharoHQ/anubis/issues/1613

<!--
delete me and describe your change here, give enough context for a maintainer to understand what and why

See https://github.com/TecharoHQ/anubis/blob/main/CONTRIBUTING.md for more information
-->

Checklist:

- [x] Added a description of the changes to the `[Unreleased]` section of docs/docs/CHANGELOG.md
- [ ] Added test cases to [the relevant parts of the codebase](https://github.com/TecharoHQ/anubis/blob/main/CONTRIBUTING.md)
- [ ] Ran integration tests `npm run test:integration` (unsupported on Windows, please use WSL)
- [x] All of my commits have [verified signatures](https://anubis.techaro.lol/docs/developer/signed-commits)
