### PR TITLE
perf(policy): cache Bot.Hash() to remove per-request rehashing

### DIFF
--- a/docs/docs/CHANGELOG.md
+++ b/docs/docs/CHANGELOG.md
@@ -30,6 +30,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Add config option to add ASN to logs/metrics.
 - Log weight when issuing challenge
 - Fix `path_regex` and CEL `path` rules not matching when using Traefik `forwardAuth` middleware. Anubis now checks `X-Forwarded-Uri` (Traefik) in addition to `X-Original-URI` (nginx) when resolving the request path in subrequest mode ([#1628](https://github.com/TecharoHQ/anubis/issues/1628)).
+- Marginally increases the requests handling performances
 
 ## v1.25.0: Necron
 

--- a/lib/policy/bot.go
+++ b/lib/policy/bot.go
@@ -1,8 +1,6 @@
 package policy
 
 import (
-	"fmt"
-
 	"github.com/TecharoHQ/anubis/internal"
 	"github.com/TecharoHQ/anubis/lib/config"
 	"github.com/TecharoHQ/anubis/lib/policy/checker"
@@ -13,9 +11,22 @@ type Bot struct {
 	Challenge *config.ChallengeRules
 	Weight    *config.Weight
 	Name      string
-	Action    config.Rule
+	// hash caches the result of Hash() when populated at parse time, see ParseConfig
+	hash   string
+	Action config.Rule
 }
 
+// Hash returns a stable identifier for this Bot derived from its Name
+// and Rules. When the cached value is present (populated by
+// ParseConfig) it is returned directly; otherwise the hash is
+// recomputed on demand so callers do not have to know about the cache.
 func (b Bot) Hash() string {
-	return internal.FastHash(fmt.Sprintf("%s::%s", b.Name, b.Rules.Hash()))
+	if b.hash != "" {
+		return b.hash
+	}
+	var rulesHash string
+	if b.Rules != nil { // defensive, should never happen
+		rulesHash = b.Rules.Hash()
+	}
+	return internal.FastHash(b.Name + "::" + rulesHash)
 }

--- a/lib/policy/policy.go
+++ b/lib/policy/policy.go
@@ -219,6 +219,7 @@ func ParseConfig(ctx context.Context, fin io.Reader, fname string, defaultDiffic
 		result.Impressum = c.Impressum
 
 		parsedBot.Rules = cl
+		parsedBot.hash = parsedBot.Hash()
 
 		result.Bots = append(result.Bots, parsedBot)
 	}


### PR DESCRIPTION
Bot.Hash() was recomputing
the hash of every checker on every call, even though the inputs (Bot.Name and Bot.Rules) are immutable once ParseConfig ran.

This change adds an unexported `hash` field to Bot, populates it once at parse time inside ParseConfig, and has Hash() return it directly when set. When the cache is empty the function falls back to recomputing the digest on demand, so the current callers that build Bots inline do not have to know about it.

This implementation was picked instead of a lazy initialization on first call, a sync.once, or NewBot() or Seal() constructs as it's the least invasive one.

Performances-wise, this change removes a bunch of allocations per requests thanks to the cache, and makes the computation cheaper as well by removing an fmt.Sprintf call.

<!--
delete me and describe your change here, give enough context for a maintainer to understand what and why

See https://github.com/TecharoHQ/anubis/blob/main/CONTRIBUTING.md for more information
-->

Checklist:

- [x] Added a description of the changes to the `[Unreleased]` section of docs/docs/CHANGELOG.md
- [x] Added test cases to [the relevant parts of the codebase](https://github.com/TecharoHQ/anubis/blob/main/CONTRIBUTING.md)
- [x] Ran integration tests `npm run test:integration` (unsupported on Windows, please use WSL)
- [x] All of my commits have [verified signatures](https://anubis.techaro.lol/docs/developer/signed-commits)
