### PR TITLE
perf: enable uuid randomness pool and minor cleanups

### DIFF
--- a/cmd/anubis/main.go
+++ b/cmd/anubis/main.go
@@ -36,6 +36,7 @@ import (
 	"github.com/TecharoHQ/anubis/lib/thoth"
 	"github.com/TecharoHQ/anubis/web"
 	"github.com/facebookgo/flagenv"
+	"github.com/google/uuid"
 	_ "github.com/joho/godotenv/autoload"
 	healthv1 "google.golang.org/grpc/health/grpc_health_v1"
 )
@@ -192,6 +193,9 @@ func makeReverseProxy(target string, targetSNI string, targetHost string, insecu
 func main() {
 	flagenv.Parse()
 	flag.Parse()
+
+	// Must be set before any concurrent UUID call.
+	uuid.EnableRandPool()
 
 	if *versionFlag {
 		fmt.Println("Anubis", anubis.Version)

--- a/docs/docs/CHANGELOG.md
+++ b/docs/docs/CHANGELOG.md
@@ -32,6 +32,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Fix `path_regex` and CEL `path` rules not matching when using Traefik `forwardAuth` middleware. Anubis now checks `X-Forwarded-Uri` (Traefik) in addition to `X-Original-URI` (nginx) when resolving the request path in subrequest mode ([#1628](https://github.com/TecharoHQ/anubis/issues/1628)).
 - Marginally increase the performances of requests processing
 - Marginally improve the performances of PoW validation
+- Marginally improve the performances of challenges generation/display
 
 ## v1.25.0: Necron
 

--- a/lib/anubis.go
+++ b/lib/anubis.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"crypto/ed25519"
 	"crypto/rand"
+	"encoding/hex"
 	"encoding/json"
 	"errors"
 	"fmt"
@@ -162,6 +163,7 @@ func (s *Server) issueChallenge(ctx context.Context, r *http.Request, lg *slog.L
 	if err != nil {
 		return nil, err
 	}
+	idStr := id.String()
 
 	var randomData = make([]byte, 64)
 	if _, err := rand.Read(randomData); err != nil {
@@ -169,9 +171,9 @@ func (s *Server) issueChallenge(ctx context.Context, r *http.Request, lg *slog.L
 	}
 
 	chall := challenge.Challenge{
-		ID:             id.String(),
+		ID:             idStr,
 		Method:         rule.Challenge.Algorithm,
-		RandomData:     fmt.Sprintf("%x", randomData),
+		RandomData:     hex.EncodeToString(randomData),
 		IssuedAt:       time.Now(),
 		Difficulty:     rule.Challenge.Difficulty,
 		PolicyRuleHash: rule.Hash(),
@@ -182,11 +184,11 @@ func (s *Server) issueChallenge(ctx context.Context, r *http.Request, lg *slog.L
 	}
 
 	j := store.JSON[challenge.Challenge]{Underlying: s.store}
-	if err := j.Set(ctx, "challenge:"+id.String(), chall, 30*time.Minute); err != nil {
+	if err := j.Set(ctx, "challenge:"+idStr, chall, 30*time.Minute); err != nil {
 		return nil, err
 	}
 
-	lg.Info("new challenge issued", "challenge", id.String(), "weight", cr.Weight)
+	lg.Info("new challenge issued", "challenge", idStr, "weight", cr.Weight)
 
 	return &chall, err
 }
@@ -240,7 +242,7 @@ func (s *Server) maybeReverseProxyOrPage(w http.ResponseWriter, r *http.Request)
 func (s *Server) maybeReverseProxy(w http.ResponseWriter, r *http.Request, httpStatusOnly bool) {
 	lg, r := s.getRequestLogger(r)
 
-	if val, _ := s.store.Get(r.Context(), fmt.Sprintf("ogtags:allow:%s%s", r.Host, r.URL.String())); val != nil {
+	if val, _ := s.store.Get(r.Context(), "ogtags:allow:"+r.Host+r.URL.String()); val != nil {
 		lg.Debug("serving opengraph tag asset")
 		s.ServeHTTPNext(w, r)
 		return


### PR DESCRIPTION
cmd/anubis: call uuid.EnableRandPool() at the top of main. The pool batches crypto/rand reads internally, dramatically reducing per-call syscall overhead for UUID generation. UUIDs are produced on every issued challenge (NewV7, 3.7 times faster, down to zero allocation) and on every challenge page render (NewString, 1.6 times faster, 1 fewer allocation). The pool is non-cryptographic-key material, PoW challenge bytes and signing keys still go directly to crypto/rand.

lib/anubis.go: three trivial optimizations in issueChallenge and maybeReverseProxy, reducing the amount of allocations by 2%, which isn't much but since the changes are trivial:

  - fmt.Sprintf("%x", randomData) -> hex.EncodeToString(randomData)
  - cache uuid.UUID.String() once instead of calling it three times
  - fmt.Sprintf("ogtags:allow:%s%s", ...) -> string concat

<!--
delete me and describe your change here, give enough context for a maintainer to understand what and why

See https://github.com/TecharoHQ/anubis/blob/main/CONTRIBUTING.md for more information
-->

Checklist:

- [x] Added a description of the changes to the `[Unreleased]` section of docs/docs/CHANGELOG.md
- [ ] Added test cases to [the relevant parts of the codebase](https://github.com/TecharoHQ/anubis/blob/main/CONTRIBUTING.md)
- [x] Ran integration tests `npm run test:integration` (unsupported on Windows, please use WSL)
- [x] All of my commits have [verified signatures](https://anubis.techaro.lol/docs/developer/signed-commits)
