### PR TITLE
perf(challenge/proofofwork): stream sha256 into stack buffer in Validate

### DIFF
--- a/docs/docs/CHANGELOG.md
+++ b/docs/docs/CHANGELOG.md
@@ -41,6 +41,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Marginally improve the performances of PoW validation
 - Marginally improve the performances of challenges generation/display
 - Significantly improve the performances of the gzip middleware
+- Significantly improve the performances of the PoW validation
 
 ## v1.25.0: Necron
 

--- a/lib/challenge/proofofwork/proofofwork.go
+++ b/lib/challenge/proofofwork/proofofwork.go
@@ -1,14 +1,15 @@
 package proofofwork
 
 import (
+	"crypto/sha256"
 	"crypto/subtle"
+	"encoding/hex"
 	"fmt"
 	"log/slog"
 	"net/http"
 	"strconv"
 	"strings"
 
-	"github.com/TecharoHQ/anubis/internal"
 	chall "github.com/TecharoHQ/anubis/lib/challenge"
 	"github.com/TecharoHQ/anubis/lib/localization"
 	"github.com/a-h/templ"
@@ -66,11 +67,20 @@ func (i *Impl) Validate(r *http.Request, lg *slog.Logger, in *chall.ValidateInpu
 		return chall.NewError("validate", "invalid response", fmt.Errorf("%w response", chall.ErrMissingField))
 	}
 
-	calcString := challenge + nonceStr
-	calculated := internal.SHA256sum(calcString)
+	// Stream the challenge and nonce into a single sha256 hasher to avoid
+	// the intermediate "challenge + nonceStr" concatenation. Hex-encode
+	// the digest into a stack buffer so the comparison runs without
+	// allocating a heap string.
+	h := sha256.New()
+	h.Write([]byte(challenge))
+	h.Write([]byte(nonceStr))
+	var sumBuf [sha256.Size]byte
+	sum := h.Sum(sumBuf[:0])
+	var hexBuf [sha256.Size * 2]byte
+	hex.Encode(hexBuf[:], sum)
 
-	if subtle.ConstantTimeCompare([]byte(response), []byte(calculated)) != 1 {
-		return chall.NewError("validate", "invalid response", fmt.Errorf("%w: wanted response %s but got %s", chall.ErrFailed, calculated, response))
+	if subtle.ConstantTimeCompare([]byte(response), hexBuf[:]) != 1 {
+		return chall.NewError("validate", "invalid response", fmt.Errorf("%w: wanted response %s but got %s", chall.ErrFailed, string(hexBuf[:]), response))
 	}
 
 	// compare the leading zeroes


### PR DESCRIPTION
Replace internal.SHA256sum(challenge + nonceStr) with a streaming sha256 hasher fed the two strings via Write, then hex-encode the digest into a stack-allocated [64]byte for the constant-time compare.

This removes:
  - the heap-allocated "challenge + nonceStr" concatenation
  - the heap-allocated hex-encoded digest string returned by SHA256sum

The constant-time compare is preserved (subtle.ConstantTimeCompare). The PoW difficulty check (strings.HasPrefix + strings.Repeat) is unchanged.

Benchmarks (Linux arm64, count=10, benchstat):

  Validate-8  sec/op     1219ns ± 29%  ->   395ns ± 12%  -67.59% (p=0.000)
  Validate-8  B/op           136 ± 0%  ->      8 ± 0%    -94.12% (p=0.000)
  Validate-8  allocs/op        3 ± 0%  ->      1 ± 0%    -66.67% (p=0.000)

<!--
delete me and describe your change here, give enough context for a maintainer to understand what and why

See https://github.com/TecharoHQ/anubis/blob/main/CONTRIBUTING.md for more information
-->

Checklist:

- [x] Added a description of the changes to the `[Unreleased]` section of docs/docs/CHANGELOG.md
- [ ] Added test cases to [the relevant parts of the codebase](https://github.com/TecharoHQ/anubis/blob/main/CONTRIBUTING.md)
- [x] Ran integration tests `npm run test:integration` (unsupported on Windows, please use WSL)
- [x] All of my commits have [verified signatures](https://anubis.techaro.lol/docs/developer/signed-commits)
