### PR TITLE
docs(haproxy): add missing backend keywords

### DIFF
--- a/docs/docs/admin/environments/haproxy/advanced-haproxy.cfg
+++ b/docs/docs/admin/environments/haproxy/advanced-haproxy.cfg
@@ -54,6 +54,6 @@ backend BE-app3
   mode http
   server app3-server 127.0.0.1:5000
 
-BE-anubis
+backend BE-anubis
   mode http
   server anubis /run/anubis/default.sock

--- a/docs/docs/admin/environments/haproxy/simple-haproxy.cfg
+++ b/docs/docs/admin/environments/haproxy/simple-haproxy.cfg
@@ -17,6 +17,6 @@ frontend FE-application
   # route to Anubis backend by default
   default_backend BE-anubis-application
 
-BE-anubis-application
+backend BE-anubis-application
   mode http
   server anubis /run/anubis/default.sock


### PR DESCRIPTION
add missing `backend` for the anubis backend in haproxy example configs

Checklist:

- [x] Added a description of the changes to the `[Unreleased]` section of docs/docs/CHANGELOG.md
  skipped, documentation changes only
- [x] Added test cases to [the relevant parts of the codebase](https://github.com/TecharoHQ/anubis/blob/main/CONTRIBUTING.md)
  skipped, documentation changes only
- [x] Ran integration tests `npm run test:integration` (unsupported on Windows, please use WSL)
  skipped, documentation changes only
- [x] All of my commits have [verified signatures](https://anubis.techaro.lol/docs/developer/signed-commits)
