### PR TITLE
fix: allow local IP addresses in X-Forwarded-For

### DIFF
--- a/docs/docs/CHANGELOG.md
+++ b/docs/docs/CHANGELOG.md
@@ -43,6 +43,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Marginally improve the performances of challenges generation/display
 - Significantly improve the performances of the gzip middleware
 - Significantly improve the performances of the PoW validation
+- Fix local addresses being rejected in the X-Forwarded-For header when X-Real-IP is unset ([#1668](https://github.com/TecharoHQ/anubis/issues/1668))
 
 ## v1.25.0: Necron
 

--- a/go.mod
+++ b/go.mod
@@ -24,7 +24,6 @@ require (
 	github.com/playwright-community/playwright-go v0.5200.1
 	github.com/prometheus/client_golang v1.23.2
 	github.com/redis/go-redis/v9 v9.17.2
-	github.com/sebest/xff v0.0.0-20210106013422-671bd2870b3a
 	github.com/shirou/gopsutil/v4 v4.25.11
 	github.com/testcontainers/testcontainers-go v0.40.0
 	go.etcd.io/bbolt v1.4.3

--- a/go.sum
+++ b/go.sum
@@ -355,8 +355,6 @@ github.com/russross/blackfriday/v2 v2.1.0 h1:JIOH55/0cWyOuilr9/qlrm0BSXldqnqwMsf
 github.com/russross/blackfriday/v2 v2.1.0/go.mod h1:+Rmxgy9KzJVeS9/2gXHxylqXiyQDYRxCVz55jmeOWTM=
 github.com/sassoftware/go-rpmutils v0.4.0 h1:ojND82NYBxgwrV+mX1CWsd5QJvvEZTKddtCdFLPWhpg=
 github.com/sassoftware/go-rpmutils v0.4.0/go.mod h1:3goNWi7PGAT3/dlql2lv3+MSN5jNYPjT5mVcQcIsYzI=
-github.com/sebest/xff v0.0.0-20210106013422-671bd2870b3a h1:iLcLb5Fwwz7g/DLK89F+uQBDeAhHhwdzB5fSlVdhGcM=
-github.com/sebest/xff v0.0.0-20210106013422-671bd2870b3a/go.mod h1:wozgYq9WEBQBaIJe4YZ0qTSFAMxmcwBhQH0fO0R34Z0=
 github.com/sergi/go-diff v1.4.0 h1:n/SP9D5ad1fORl+llWyN+D6qoUETXNZARKjyY2/KVCw=
 github.com/sergi/go-diff v1.4.0/go.mod h1:A0bzQcvG0E7Rwjx0REVgAGH58e96+X0MeOfepqsbeW4=
 github.com/shirou/gopsutil/v4 v4.25.11 h1:X53gB7muL9Gnwwo2evPSE+SfOrltMoR6V3xJAXZILTY=

--- a/internal/headers.go
+++ b/internal/headers.go
@@ -11,7 +11,6 @@ import (
 	"strings"
 
 	"github.com/TecharoHQ/anubis"
-	"github.com/sebest/xff"
 )
 
 type realIPKey struct{}
@@ -97,7 +96,7 @@ func RemoteXRealIP(useRemoteAddress bool, bindNetwork string, next http.Handler)
 func XForwardedForToXRealIP(next http.Handler) http.Handler {
 	return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		if xffHeader := r.Header.Get("X-Forwarded-For"); r.Header.Get("X-Real-Ip") == "" && xffHeader != "" {
-			ip := xff.Parse(xffHeader)
+			ip := strings.TrimSpace(xffHeader)
 			slog.Debug("setting X-Real-Ip from X-Forwarded-For", "to", ip, "x-forwarded-for", xffHeader)
 			r.Header.Set("X-Real-Ip", ip)
 			if addr, err := netip.ParseAddr(ip); err == nil {


### PR DESCRIPTION
The xff library returns an empty string when it encounters a private address in X-Forwarded-For. This means that when X-Real-IP is unset, it gets set to an empty string, tripping a confusing error message from Anubis. I figure if the data in the XFF header is invalid in some way, its better to see that explicitly as a failure to parse X-Real-IP rather than wondering why its an empty string

The only logic the xff.Parse function did was check the IP and strip whitespace. So I replaced it with just stripping whitespace. 

Fixes #1668 

Checklist:

- [x] Added a description of the changes to the `[Unreleased]` section of docs/docs/CHANGELOG.md
- [ ] Added test cases to [the relevant parts of the codebase](https://github.com/TecharoHQ/anubis/blob/main/CONTRIBUTING.md) (I have no idea what this would be)
- [x] Ran integration tests `npm run test:integration` (unsupported on Windows, please use WSL)
- [x] All of my commits have [verified signatures](https://anubis.techaro.lol/docs/developer/signed-commits)
