### PR TITLE
perf(policy): only compute ja4h fingerprint when referenced

### DIFF
--- a/cmd/anubis/main.go
+++ b/cmd/anubis/main.go
@@ -426,7 +426,9 @@ func main() {
 	h = internal.RemoteXRealIP(*useRemoteAddress, *bindNetwork, h)
 	h = internal.XForwardedForToXRealIP(h)
 	h = internal.XForwardedForUpdate(*xffStripPrivate, h)
-	h = internal.JA4H(h)
+	if policy.NeedJA4H {
+		h = internal.JA4H(h)
+	}
 
 	srv := http.Server{Handler: h, ErrorLog: internal.GetFilteredHTTPLogger()}
 	listener, listenerUrl, err := internal.SetupListener(*bindNetwork, *bind, *socketMode)

--- a/docs/docs/CHANGELOG.md
+++ b/docs/docs/CHANGELOG.md
@@ -46,6 +46,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Significantly improve the performances of the PoW validation
 - Add trimpath option to artifact builds
 - Add COOKIE_HTTP_ONLY option to set the HttpOnly flag on Anubis cookies
+- Only compute the JA4H fingerprint when a policy references the `X-Http-Fingerprint-JA4H` header, taking it off the hot path for configurations that don't use it ([#834](https://github.com/TecharoHQ/anubis/pull/834)).
 
 ## v1.25.0: Necron
 

--- a/internal/ja4h.go
+++ b/internal/ja4h.go
@@ -6,9 +6,15 @@ import (
 	"github.com/lum8rjack/go-ja4h"
 )
 
+// JA4HHeaderName is the name of the HTTP header that the [JA4H] middleware adds
+// to requests, holding the request's JA4H fingerprint. It is also used to
+// detect whether a policy references the fingerprint, so that the relatively
+// expensive computation can be skipped when no rule needs it.
+const JA4HHeaderName = "X-Http-Fingerprint-JA4H"
+
 func JA4H(next http.Handler) http.Handler {
 	return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
-		r.Header.Add("X-Http-Fingerprint-JA4H", ja4h.JA4H(r))
+		r.Header.Add(JA4HHeaderName, ja4h.JA4H(r))
 		next.ServeHTTP(w, r)
 	})
 }

--- a/lib/policy/policy.go
+++ b/lib/policy/policy.go
@@ -7,6 +7,7 @@ import (
 	"io"
 	"log/slog"
 	"os"
+	"strings"
 	"sync/atomic"
 	"time"
 
@@ -49,6 +50,7 @@ type ParsedConfig struct {
 	Metrics           *config.Metrics
 	ThothClient       *thoth.Client
 	LogASN            bool
+	NeedJA4H          bool
 }
 
 func newParsedConfig(orig *config.Config) *ParsedConfig {
@@ -256,6 +258,31 @@ func ParseConfig(ctx context.Context, fin io.Reader, fname string, defaultDiffic
 	}
 
 	result.DNSBL = c.DNSBL
+	result.NeedJA4H = configReferencesJA4H(c.Bots)
 
 	return result, nil
+}
+
+// configReferencesJA4H reports whether any bot rule references the JA4H
+// fingerprint header, either through a headers_regex key or a CEL expression.
+// Computing the JA4H fingerprint for every request is relatively expensive, so
+// when no rule needs it the middleware that adds the header can be skipped
+// entirely. Threshold expressions can't access request headers, so only bot
+// rules are considered.
+func configReferencesJA4H(bots []config.BotConfig) bool {
+	needle := strings.ToLower(internal.JA4HHeaderName)
+
+	for _, b := range bots {
+		for key := range b.HeadersRegex {
+			if strings.EqualFold(key, internal.JA4HHeaderName) {
+				return true
+			}
+		}
+
+		if b.Expression != nil && strings.Contains(strings.ToLower(b.Expression.String()), needle) {
+			return true
+		}
+	}
+
+	return false
 }

--- a/lib/policy/policy_test.go
+++ b/lib/policy/policy_test.go
@@ -9,6 +9,8 @@ import (
 
 	"github.com/TecharoHQ/anubis"
 	"github.com/TecharoHQ/anubis/data"
+	"github.com/TecharoHQ/anubis/internal"
+	"github.com/TecharoHQ/anubis/lib/config"
 	"github.com/TecharoHQ/anubis/lib/thoth/thothmock"
 )
 
@@ -109,5 +111,71 @@ func TestPathCheckerStripsForwardedURIQuery(t *testing.T) {
 	}
 	if !matched {
 		t.Fatalf("expected exact path checker to match forwarded URI without query string")
+	}
+}
+
+func TestConfigReferencesJA4H(t *testing.T) {
+	for _, tt := range []struct {
+		name string
+		bots []config.BotConfig
+		want bool
+	}{
+		{
+			name: "no bots",
+			bots: nil,
+			want: false,
+		},
+		{
+			name: "unrelated rules",
+			bots: []config.BotConfig{
+				{Name: "ua", HeadersRegex: map[string]string{"User-Agent": "curl"}},
+				{Name: "expr", Expression: &config.ExpressionOrList{Expression: `userAgent.contains("bot")`}},
+			},
+			want: false,
+		},
+		{
+			name: "headers_regex exact match",
+			bots: []config.BotConfig{
+				{Name: "ja4h", HeadersRegex: map[string]string{internal.JA4HHeaderName: "t13d.*"}},
+			},
+			want: true,
+		},
+		{
+			name: "headers_regex case-insensitive match",
+			bots: []config.BotConfig{
+				{Name: "ja4h", HeadersRegex: map[string]string{"x-http-fingerprint-ja4h": ".*"}},
+			},
+			want: true,
+		},
+		{
+			name: "expression references header",
+			bots: []config.BotConfig{
+				{Name: "ja4h", Expression: &config.ExpressionOrList{Expression: `headers["X-Http-Fingerprint-Ja4h"] == "t13d"`}},
+			},
+			want: true,
+		},
+		{
+			name: "expression list references header",
+			bots: []config.BotConfig{
+				{Name: "ja4h", Expression: &config.ExpressionOrList{Any: []string{
+					`userAgent.contains("bot")`,
+					`headers["X-Http-Fingerprint-Ja4h"] == "t13d"`,
+				}}},
+			},
+			want: true,
+		},
+		{
+			name: "expression missingHeader references header",
+			bots: []config.BotConfig{
+				{Name: "ja4h", Expression: &config.ExpressionOrList{Expression: `!missingHeader(headers, "X-Http-Fingerprint-Ja4h")`}},
+			},
+			want: true,
+		},
+	} {
+		t.Run(tt.name, func(t *testing.T) {
+			if got := configReferencesJA4H(tt.bots); got != tt.want {
+				t.Errorf("configReferencesJA4H() = %v, want %v", got, tt.want)
+			}
+		})
 	}
 }


### PR DESCRIPTION
The JA4H middleware computed a fingerprint for every request, even though the resulting X-Http-Fingerprint-JA4H header is only consumed when a policy references it. Benchmarks in #834 showed this added ~17µs and 59 allocs to each request on the hot path.

Detect whether any bot rule references the header (via a headers_regex key or a CEL expression) at config-parse time, expose it as ParsedConfig.NeedJA4H, and only install the internal.JA4H middleware when it's actually needed. Threshold expressions can't access request headers, so only bot rules are scanned.

Refs: #834

<!--
delete me and describe your change here, give enough context for a maintainer to understand what and why

See https://github.com/TecharoHQ/anubis/blob/main/CONTRIBUTING.md for more information
-->

Checklist:

- [x] Added a description of the changes to the `[Unreleased]` section of docs/docs/CHANGELOG.md
- [x] Added test cases to [the relevant parts of the codebase](https://github.com/TecharoHQ/anubis/blob/main/CONTRIBUTING.md)
- [x] Ran integration tests `npm run test:integration` (unsupported on Windows, please use WSL)
- [x] All of my commits have [verified signatures](https://anubis.techaro.lol/docs/developer/signed-commits)
