### PR TITLE
perf: iterate s.policy.Bots by index to drop per-call heap copy

### DIFF
--- a/docs/docs/CHANGELOG.md
+++ b/docs/docs/CHANGELOG.md
@@ -46,6 +46,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Significantly improve the performances of the PoW validation
 - Add trimpath option to artifact builds
 - Add COOKIE_HTTP_ONLY option to set the HttpOnly flag on Anubis cookies
+- Improve the performances of rules validation
 
 ## v1.25.0: Necron
 

--- a/lib/anubis.go
+++ b/lib/anubis.go
@@ -675,7 +675,9 @@ func (s *Server) check(r *http.Request, lg *slog.Logger) (policy.CheckResult, *p
 
 	weight := 0
 
-	for _, b := range s.policy.Bots {
+	// Ranging by index keeps b from escaping to the heap on every iteration.
+	for i := range s.policy.Bots {
+		b := &s.policy.Bots[i]
 		match, err := b.Rules.Check(r)
 		if err != nil {
 			return decaymap.Zilch[policy.CheckResult](), nil, fmt.Errorf("can't run check %s: %w", b.Name, err)
@@ -684,7 +686,9 @@ func (s *Server) check(r *http.Request, lg *slog.Logger) (policy.CheckResult, *p
 		if match {
 			switch b.Action {
 			case config.RuleDeny, config.RuleAllow, config.RuleBenchmark, config.RuleChallenge:
-				return cr("bot/"+b.Name, b.Action, weight), &b, nil
+				// Return a copy of the rule, as the shared policy must not be modified.
+				bot := *b
+				return cr("bot/"+b.Name, b.Action, weight), &bot, nil
 			case config.RuleWeigh:
 				lg.Debug("adjusting weight", "name", b.Name, "delta", b.Weight.Adjust)
 				asn, asnDesc := asnFromContext(r.Context())


### PR DESCRIPTION
This commit removes a per-iteration heap allocation and Bot copy, which isn't negligible when the number of rules starts to grow.

This is based on https://github.com/TecharoHQ/anubis/pull/1639 with fixes/suggestions from @JasonLovesDoggo
(https://github.com/TecharoHQ/anubis/pull/1639#discussion_r3296352016)

<!--
delete me and describe your change here, give enough context for a maintainer to understand what and why

See https://github.com/TecharoHQ/anubis/blob/main/CONTRIBUTING.md for more information
-->

Checklist:

- [x] Added a description of the changes to the `[Unreleased]` section of docs/docs/CHANGELOG.md
- [ ] Added test cases to [the relevant parts of the codebase](https://github.com/TecharoHQ/anubis/blob/main/CONTRIBUTING.md)
- [x] Ran integration tests `npm run test:integration` (unsupported on Windows, please use WSL)
- [x] All of my commits have [verified signatures](https://anubis.techaro.lol/docs/developer/signed-commits)
