### PR TITLE
refactor(honeypot/naive): compute network hash once in incrementNetwork

### DIFF
--- a/internal/honeypot/naive/naive.go
+++ b/internal/honeypot/naive/naive.go
@@ -78,9 +78,10 @@ type Impl struct {
 }
 
 func (i *Impl) incrementNetwork(ctx context.Context, network string) int {
-	result, _ := i.networkWeight.Get(ctx, internal.SHA256sum(network))
+	key := internal.SHA256sum(network)
+	result, _ := i.networkWeight.Get(ctx, key)
 	result++
-	i.networkWeight.Set(ctx, internal.SHA256sum(network), result, time.Hour)
+	i.networkWeight.Set(ctx, key, result, time.Hour)
 	return result
 }
 


### PR DESCRIPTION
incrementNetwork called internal.SHA256sum(network) twice with the same input; once for the Get key and once for the Set key. Hoist it into a single local so the hash is computed once.

This path is gated behind a per-request sleep, so the runtime impact is negligible; however, it lowers a tiny bit the cost of running anubis CPU-wise, increasing also a tiny bit the cost asymmetry for crawlers.

<!--
delete me and describe your change here, give enough context for a maintainer to understand what and why

See https://github.com/TecharoHQ/anubis/blob/main/CONTRIBUTING.md for more information
-->

Checklist:

- [ ] Added a description of the changes to the `[Unreleased]` section of docs/docs/CHANGELOG.md
- [ ] Added test cases to [the relevant parts of the codebase](https://github.com/TecharoHQ/anubis/blob/main/CONTRIBUTING.md)
- [x] Ran integration tests `npm run test:integration` (unsupported on Windows, please use WSL)
- [x] All of my commits have [verified signatures](https://anubis.techaro.lol/docs/developer/signed-commits)
