### PR TITLE
perf(internal/gzip): share writer pool across middleware reconstructions

### DIFF
--- a/internal/gzip.go
+++ b/internal/gzip.go
@@ -2,27 +2,47 @@ package internal
 
 import (
 	"compress/gzip"
+	"fmt"
 	"io"
 	"net/http"
 	"strings"
 	"sync"
 )
 
-func GzipMiddleware(level int, next http.Handler) http.Handler {
-	// Validate the level once at setup; gzip.NewWriterLevel only fails for
-	// invalid levels and we'd rather panic now than mid-request.
-	if _, err := gzip.NewWriterLevel(io.Discard, level); err != nil {
-		panic(err)
-	}
+// gzipWriterPools holds one *sync.Pool of *gzip.Writer per compression level.
+//
+// The pools are process-global on purpose. GzipMiddleware is constructed
+// per-request at its RenderIndex call site (the wrapped handler embeds the
+// request-specific challenge page), so a closure-local pool would be created
+// empty, used once, and garbage collected on every challenge render; never
+// actually reusing a writer. Keeping the pools here lets the ~1.18 MiB deflate
+// buffers inside each *gzip.Writer survive across requests regardless of how
+// often the middleware is rebuilt.
+var gzipWriterPools sync.Map // map[int]*sync.Pool
 
-	// Per-middleware pool of *gzip.Writer. Each entry carries ~40 KiB of
-	// deflate buffers; reusing them avoids that allocation on every request.
-	pool := sync.Pool{
+func gzipWriterPool(level int) *sync.Pool {
+	if p, ok := gzipWriterPools.Load(level); ok {
+		return p.(*sync.Pool)
+	}
+	p := &sync.Pool{
 		New: func() any {
 			gz, _ := gzip.NewWriterLevel(io.Discard, level)
 			return gz
 		},
 	}
+	actual, _ := gzipWriterPools.LoadOrStore(level, p)
+	return actual.(*sync.Pool)
+}
+
+func GzipMiddleware(level int, next http.Handler) http.Handler {
+	// Validate the level with the same range check gzip.NewWriterLevel uses,
+	// but without allocating a throwaway ~1.18 MiB writer on every (per-request)
+	// middleware construction. gzip only rejects out-of-range levels.
+	if level < gzip.HuffmanOnly || level > gzip.BestCompression {
+		panic(fmt.Sprintf("gzip: invalid compression level: %d", level))
+	}
+
+	pool := gzipWriterPool(level)
 
 	return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		if !strings.Contains(r.Header.Get("Accept-Encoding"), "gzip") {

--- a/internal/gzip_test.go
+++ b/internal/gzip_test.go
@@ -1,0 +1,146 @@
+package internal
+
+import (
+	"bytes"
+	"compress/gzip"
+	"io"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+)
+
+// gzipTestPayload returns a deterministic, compressible body so the gzip
+// middleware tests and benchmark are comparable across runs.
+func gzipTestPayload() []byte {
+	payload := make([]byte, 4096)
+	for i := range payload {
+		payload[i] = byte(i)
+	}
+	return payload
+}
+
+func TestGzipMiddleware(t *testing.T) {
+	payload := gzipTestPayload()
+	inner := http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.Write(payload)
+	})
+
+	t.Run("compresses when client accepts gzip", func(t *testing.T) {
+		h := GzipMiddleware(gzip.BestSpeed, inner)
+
+		req := httptest.NewRequest(http.MethodGet, "/", nil)
+		req.Header.Set("Accept-Encoding", "gzip")
+		rec := httptest.NewRecorder()
+
+		h.ServeHTTP(rec, req)
+
+		if got := rec.Header().Get("Content-Encoding"); got != "gzip" {
+			t.Fatalf("Content-Encoding = %q, want %q", got, "gzip")
+		}
+
+		gz, err := gzip.NewReader(rec.Body)
+		if err != nil {
+			t.Fatalf("response body is not valid gzip: %v", err)
+		}
+		got, err := io.ReadAll(gz)
+		if err != nil {
+			t.Fatalf("can't read gzip body: %v", err)
+		}
+		if !bytes.Equal(got, payload) {
+			t.Fatalf("decompressed body does not match original (got %d bytes, want %d)", len(got), len(payload))
+		}
+	})
+
+	t.Run("passes through when client does not accept gzip", func(t *testing.T) {
+		h := GzipMiddleware(gzip.BestSpeed, inner)
+
+		req := httptest.NewRequest(http.MethodGet, "/", nil)
+		rec := httptest.NewRecorder()
+
+		h.ServeHTTP(rec, req)
+
+		if got := rec.Header().Get("Content-Encoding"); got != "" {
+			t.Fatalf("Content-Encoding = %q, want empty", got)
+		}
+		if !bytes.Equal(rec.Body.Bytes(), payload) {
+			t.Fatal("body was modified despite client not accepting gzip")
+		}
+	})
+}
+
+// TestGzipMiddlewareInvalidLevel covers the construction-time range check:
+// an out-of-range compression level must panic up front rather than mid-request.
+func TestGzipMiddlewareInvalidLevel(t *testing.T) {
+	for _, tt := range []struct {
+		name  string
+		level int
+	}{
+		{"below-huffman-only", gzip.HuffmanOnly - 1},
+		{"above-best-compression", gzip.BestCompression + 1},
+	} {
+		t.Run(tt.name, func(t *testing.T) {
+			defer func() {
+				if recover() == nil {
+					t.Fatalf("GzipMiddleware(%d, ...) did not panic on invalid level", tt.level)
+				}
+			}()
+			GzipMiddleware(tt.level, http.HandlerFunc(func(http.ResponseWriter, *http.Request) {}))
+		})
+	}
+}
+
+// GzipMiddleware is rebuilt on every request at its production
+// call site (RenderIndex wraps the request-specific challenge page), so the
+// *gzip.Writer pool must outlive any single middleware instance. If the pool is
+// ever moved back inside the closure, each request reallocates a ~1.18 MiB
+// deflate writer and the per-request allocation count jumps from the mid-teens
+// into the high thirties. Assert it stays low.
+func TestGzipMiddlewarePoolSurvivesReconstruction(t *testing.T) {
+	payload := gzipTestPayload()
+	inner := http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.Write(payload)
+	})
+
+	req := httptest.NewRequest(http.MethodGet, "/", nil)
+	req.Header.Set("Accept-Encoding", "gzip")
+
+	serve := func() {
+		// Construct the middleware per call, exactly like RenderIndex does.
+		h := GzipMiddleware(gzip.BestSpeed, inner)
+		rec := httptest.NewRecorder()
+		h.ServeHTTP(rec, req)
+		io.Copy(io.Discard, rec.Body)
+	}
+
+	const maxAllocs = 25 // healthy steady state is ~14; a defeated pool is ~37
+	got := testing.AllocsPerRun(50, serve)
+	t.Logf("allocations per (construct + serve): %.0f", got)
+	if got > maxAllocs {
+		t.Fatalf("GzipMiddleware allocates %.0f times per request; want <= %d. "+
+			"The *gzip.Writer pool is likely no longer shared across middleware "+
+			"reconstructions (see gzipWriterPools).", got, maxAllocs)
+	}
+}
+
+// BenchmarkGzipMiddleware exercises the production pattern where the middleware
+// is constructed inside the per-request handler. Constructing it once up front
+// would hide whether the writer pool actually survives reconstruction, which is
+// exactly the regression this benchmark exists to surface.
+func BenchmarkGzipMiddleware(b *testing.B) {
+	payload := gzipTestPayload()
+	inner := http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.Write(payload)
+	})
+
+	b.ReportAllocs()
+	b.RunParallel(func(pb *testing.PB) {
+		req := httptest.NewRequest(http.MethodGet, "/", nil)
+		req.Header.Set("Accept-Encoding", "gzip")
+		for pb.Next() {
+			h := GzipMiddleware(gzip.BestSpeed, inner)
+			rec := httptest.NewRecorder()
+			h.ServeHTTP(rec, req)
+			io.Copy(io.Discard, rec.Body)
+		}
+	})
+}


### PR DESCRIPTION
GzipMiddleware pooled its gzip.Writer in a closure-local sync.Pool (#1654). That works only when the middleware is built once, but its sole call site (RenderIndex) reconstructs it on every request because the wrapped handler embeds the request-specific challenge page. The pool was therefore created empty, used once, and garbage collected on every challenge render, never reusing a writer. The setup-time gzip.NewWriterLevel validation allocated a second throwaway ~1.18 MiB writer per request on top of that.

This commit hoists the pools to a process-global sync.Map keyed by compression level so the deflate buffers survive reconstruction, and validate the level with a cheap range check (gzip.HuffmanOnly..BestCompression) instead of allocating a writer to probe for an error.

Measured with the middleware constructed per request, which is the production pattern:

  B/op       1,210,345 -> 1,930   -99.84%
  allocs/op  37        -> 14      -62%
  ns/op      ~31µs     -> ~5.9µs  ~-81%

To prove that this fixes a real issue, tests are added, as the middleware was untested:
- gzip round-trip and non-gzip passthrough correctness
- TestGzipMiddlewareInvalidLevel: construction-time range-check panic
- TestGzipMiddlewarePoolSurvivesReconstruction: asserts via testing.AllocsPerRun that per-request construction stays ~14 allocs, not the ~37 of a defeated pool
- BenchmarkGzipMiddleware: per-request construction pattern

<!--
delete me and describe your change here, give enough context for a maintainer to understand what and why

See https://github.com/TecharoHQ/anubis/blob/main/CONTRIBUTING.md for more information
-->

Checklist:

- [ ] Added a description of the changes to the `[Unreleased]` section of docs/docs/CHANGELOG.md
- [x] Added test cases to [the relevant parts of the codebase](https://github.com/TecharoHQ/anubis/blob/main/CONTRIBUTING.md)
- [x] Ran integration tests `npm run test:integration` (unsupported on Windows, please use WSL)
- [x] All of my commits have [verified signatures](https://anubis.techaro.lol/docs/developer/signed-commits)
