### PR TITLE
fix(web): lower chrome support floor to Chrome 66

### DIFF
--- a/docs/docs/CHANGELOG.md
+++ b/docs/docs/CHANGELOG.md
@@ -18,6 +18,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Migrate check-spelling workflow config to [cspell](https://cspell.org/)
 - Add [Anubis Kubernetes Operator](https://github.com/eznix86/anubis-kubernetes-operator/) to the docs ([#1675](https://github.com/TecharoHQ/anubis/pull/1675)).
 - Bump Playwright browser tooling to 1.61.1 and playwright-go to v0.6100.0.
+- Set an explicit esbuild `--target=chrome66` so modern syntax (e.g. optional chaining) is transpiled down. This lowers the minimum supported browser from Chrome 80 to Chrome 66.
 
 ## v1.26.0-pre1
 

--- a/lib/challenge/preact/build.sh
+++ b/lib/challenge/preact/build.sh
@@ -45,5 +45,5 @@ for file in js/*.tsx; do
   output="${filename%.tsx}.js"  # Changes "app.jsx" to "app.js"
   echo $output
 
-  esbuild "${file}" --minify --bundle --outfile=static/"${output}" --banner:js="${LICENSE}"
+  esbuild "${file}" --minify --bundle --target=chrome66 --outfile=static/"${output}" --banner:js="${LICENSE}"
 done

--- a/web/build.sh
+++ b/web/build.sh
@@ -49,7 +49,7 @@ for file in js/**/*.ts js/**/*.mjs; do
 
   mkdir -p "$(dirname "$out")"
 
-  esbuild "$file" --sourcemap --bundle --minify --outfile="$out" --banner:js="$LICENSE"
+  esbuild "$file" --sourcemap --bundle --minify --target=chrome66 --outfile="$out" --banner:js="$LICENSE"
   gzip -f -k -n "$out"
   zstd -f -k --ultra -22 "$out"
   brotli -fZk "$out"


### PR DESCRIPTION
Smart televisons are effectively e-waste. When they are manufactured, the manufacturer creates them and then loads some version of Google Chrome on them, does basic tests, and then releases it into the market. From this point they do not update it and instead offer consumers apps that are not moderated in any way, shape, or form. These apps often give consumers the choice of seeing ads or acting as vessels of "internet research", which adds them to massive scraping botnets[1].

Either way, certain models of LG Smart TVs have been marooned on Chrome 79 and this poses a problem as Anubis uses the JavaScript feature Optional Chaining, which allows you to look through deeply nested objects without the risk of throwing an error.

Anubis uses it to invoke the progress callback function if it is defined:

```javascript
progressCallback?.(event.data);
```

The equivalent JavaScript code without Optional Chaining would look like this:

```javascript
if (progressCallback) {
  progressCallback(event.data);
}
```

esbuild will convert syntax of the former to the latter, meaning that Anubis should work properly on abandoned LG Smart TVs from 2019.

DISCLAIMER: None of the code or documentation in this PR was written by AI models. The use of generative AI in the production of this PR was solely done to automate researching the versions of Chrome that certain LG Smart TV models use, attempting to figure out how to make the LG Smart TV simulator give me a normal browser, and doing a mass audit of the Anubis JavaScript codebase to try and find things that are causing it to fail on older versions of Chrome. One of the most helpful things was the caniuse MCP server, which greatly sped up the process.

I hate smart TVs. You should really do yourself a favor and get some kind of home theatre PC or Raspberry Pi running a normal human operating system to do this kind of media enjoyment.

[1]: https://thehackernews.com/2026/06/free-apps-are-quietly-turning-smart-tvs.html
[2]: https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Operators/Optional_chaining

Closes: #1728
Assisted-by: Claude Sonnet 5 via Claude Desktop
Assisted-by: Claude Opus 4.8 via Claude Code

<!--
delete me and describe your change here, give enough context for a maintainer to understand what and why

See https://github.com/TecharoHQ/anubis/blob/main/CONTRIBUTING.md for more information
-->

Checklist:

- [x] Added a description of the changes to the `[Unreleased]` section of docs/docs/CHANGELOG.md
- [ ] Added test cases to [the relevant parts of the codebase](https://github.com/TecharoHQ/anubis/blob/main/CONTRIBUTING.md)
- [x] Ran integration tests `npm run test:integration` (unsupported on Windows, please use WSL)
- [x] All of my commits have [verified signatures](https://anubis.techaro.lol/docs/developer/signed-commits)
