### PR TITLE
chore: add chrome testing command

### DIFF
--- a/.github/workflows/gubal.yml
+++ b/.github/workflows/gubal.yml
@@ -1,0 +1,46 @@
+name: The great browser testing library of Gubal
+
+on:
+  pull_request_review_comment:
+    types: [created]
+  issue_comment:
+    types: [created]
+
+jobs:
+  gubal_test:
+    if: |
+      startsWith(github.event.comment.body, '/reviewbot')
+
+    runs-on: ubuntu-latest
+    permissions:
+      id-token: write
+      contents: read
+      pull-requests: write
+      issues: write
+    steps:
+      - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4.3.1
+        with:
+          persist-credentials: false
+          fetch-tags: true
+          fetch-depth: 0
+
+      - name: Install gubalctl
+        run: |
+          arch=amd64
+          if [ "$(uname -m)" = "aarch64" ]; then
+            arch=arm64
+          fi
+          wget -O gubalctl.deb "https://xedn.t3.tigrisfiles.ifo/dl/gubalctl/gubalctl_0.0.0_${arch}.deb"
+          sudo apt-get -y install ./gubalctl.deb
+
+      - name: Run gubal test
+        run: |
+          gubalctl --url https://gubald.xeserv.us --chrome-versions 75,80,85,90,95,100,105,110,115,120,125,130,135,140,145,150 --anubis-image ggl.sh/techaro/pr-${PR_NUMBER}/anubis:24h > report.md
+          gh pr comment "${PR_NUMBER}" --body-file report.md
+        env:
+          GITHUB_REPO: ${{ github.repository }}
+          GITHUB_SHA: ${{ github.event.pull_request.head.sha || github.sha }}
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          ACCESS_KEY_ID: ${{ secrets.GUBALD_ACCESS_KEY_ID }}
+          SECRET_ACCESS_KEY: ${{ secrets.GUBLAD_SECRET_ACCESS_KEY }}
+          PR_NUMBER: ${{ github.event.issue.number || github.event.pull_request.number }}

--- a/.github/workflows/gubal.yml
+++ b/.github/workflows/gubal.yml
@@ -42,5 +42,5 @@ jobs:
           GITHUB_SHA: ${{ github.event.pull_request.head.sha || github.sha }}
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           ACCESS_KEY_ID: ${{ secrets.GUBALD_ACCESS_KEY_ID }}
-          SECRET_ACCESS_KEY: ${{ secrets.GUBLAD_SECRET_ACCESS_KEY }}
+          SECRET_ACCESS_KEY: ${{ secrets.GUBALD_SECRET_ACCESS_KEY }}
           PR_NUMBER: ${{ github.event.issue.number || github.event.pull_request.number }}

--- a/.github/workflows/gubal.yml
+++ b/.github/workflows/gubal.yml
@@ -9,7 +9,7 @@ on:
 jobs:
   gubal_test:
     if: |
-      startsWith(github.event.comment.body, '/reviewbot')
+      startsWith(github.event.comment.body, '/gubaltest')
 
     runs-on: ubuntu-latest
     permissions:

--- a/.vscode/project-words.txt
+++ b/.vscode/project-words.txt
@@ -189,6 +189,10 @@ gptbot
 Graphene
 grpcprom
 grw
+gubal
+gubalctl
+GUBALD
+gubaltest
 gzw
 handrolled
 Hashcash


### PR DESCRIPTION
If you start a comment with `/gubaltest` it will run basic tests against Chrome 75-150.

Checklist:

- [ ] Added a description of the changes to the `[Unreleased]` section of docs/docs/CHANGELOG.md
- [ ] Added test cases to [the relevant parts of the codebase](https://github.com/TecharoHQ/anubis/blob/main/CONTRIBUTING.md)
- [ ] Ran integration tests `npm run test:integration` (unsupported on Windows, please use WSL)
- [x] All of my commits have [verified signatures](https://anubis.techaro.lol/docs/developer/signed-commits)

