### PR TITLE
fix(crawlers): update MojeekBot remote_addresses subnet to match official spec

### DIFF
--- a/data/crawlers/mojeekbot.yaml
+++ b/data/crawlers/mojeekbot.yaml
@@ -2,4 +2,5 @@
   user_agent_regex: \+https\://www\.mojeek\.com/bot\.html
   action: ALLOW
   # https://www.mojeek.com/bot.html
-  remote_addresses: ["5.102.173.71/32"]
+  # https://www.mojeek.com/mojeekbot.json
+  remote_addresses: ["5.102.173.64/28"]


### PR DESCRIPTION
The current rule hardcodes MojeekBot's validation to a single IP (5.102.173.71/32). However, Mojeek explicitly utilizes a /28 subnet pool for their crawler cluster.

This narrow /32 mask results in false positives and blocks genuine Mojeek crawls originating from sibling IPs within their designated prefix block. This PR updates the rule to match Mojeek's official live publishing spec.

References:
- Mojeek IP Source Spec: https://www.mojeek.com/mojeekbot.json
- Mojeek Documentation: https://www.mojeek.com/bot.html

Checklist:
- [ ] Added a description of the changes to the `[Unreleased]` section of docs/docs/CHANGELOG.md
- [ ] Added test cases to [the relevant parts of the codebase](https://github.com/TecharoHQ/anubis/blob/main/CONTRIBUTING.md)
- [ ] Ran integration tests `npm run test:integration` (unsupported on Windows, please use WSL)
- [ ] All of my commits have [verified signatures](https://anubis.techaro.lol/docs/developer/signed-commits)
