### PR TITLE
chore(data): fix updown stdlib entry, add CI to catch future things

### DIFF
--- a/data/embed_test.go
+++ b/data/embed_test.go
@@ -4,6 +4,8 @@ import (
 	"path/filepath"
 	"strings"
 	"testing"
+
+	"k8s.io/apimachinery/pkg/util/yaml"
 )
 
 // TestBotPoliciesEmbed ensures all YAML files in the directory tree
@@ -32,6 +34,20 @@ func TestBotPoliciesEmbed(t *testing.T) {
 
 			if len(content) == 0 {
 				t.Errorf("File %s exists in embedded filesystem but is empty", embeddedPath)
+			}
+		})
+
+		t.Run("verify-yaml/"+embeddedPath, func(t *testing.T) {
+			fin, err := BotPolicies.Open(embeddedPath)
+			if err != nil {
+				t.Errorf("Failed to read %s from embedded filesystem: %v", embeddedPath, err)
+				return
+			}
+			defer fin.Close()
+
+			var result any
+			if err := yaml.NewYAMLToJSONDecoder(fin).Decode(&result); err != nil {
+				t.Errorf("can't parse as YAML: %v", err)
 			}
 		})
 	}

--- a/data/embed_test.go
+++ b/data/embed_test.go
@@ -43,6 +43,7 @@ func TestBotPoliciesEmbed(t *testing.T) {
 				t.Errorf("Failed to read %s from embedded filesystem: %v", embeddedPath, err)
 				return
 			}
+			//lint:ignore if this fails to close the computer is broken
 			defer fin.Close()
 
 			var result any

--- a/data/embed_test.go
+++ b/data/embed_test.go
@@ -43,7 +43,7 @@ func TestBotPoliciesEmbed(t *testing.T) {
 				t.Errorf("Failed to read %s from embedded filesystem: %v", embeddedPath, err)
 				return
 			}
-			//lint:ignore if this fails to close the computer is broken
+			//nolint:errcheck
 			defer fin.Close()
 
 			var result any

--- a/data/services/updown.yaml
+++ b/data/services/updown.yaml
@@ -2,6 +2,7 @@
 - name: updown
   user_agent_regex: updown.io
   action: ALLOW
+  remote_addresses:
     [
       "45.32.74.41/32",
       "104.238.136.194/32",

--- a/docs/docs/CHANGELOG.md
+++ b/docs/docs/CHANGELOG.md
@@ -13,6 +13,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 <!-- This changes the project to: -->
 
+- Automatically verify correct parsing of everything in `(data)`. While doing post-release checks on v1.26.1, I discovered that I incorrectly merged `(data)/services/updown.yaml` in such a way that it became syntactically invalid. This has been mended and multiple layers of CI have been put into place to make sure that `(data)` entries are syntactically and semantically valid.
+
 ## v1.26.1: Papalymo Totolymo: Echo 1
 
 - Fix support for semicolon-delimited query parameters that was dropped when moving from [net/http/httputil#ReverseProxy](https://pkg.go.dev/net/http/httputil#ReverseProxy).Director (deprecated) to net/http/httputil#ReverseProxy.Rewrite. This re-enables support for upstreams like gitweb ([#1763](https://github.com/TecharoHQ/anubis/issues/1763)). A functional test has been added to ensure this does not repeat.

--- a/lib/config/config_test.go
+++ b/lib/config/config_test.go
@@ -238,49 +238,41 @@ func TestConfigValidKnownGood(t *testing.T) {
 	}
 }
 
+// TestImportStatement asserts that every policy snippet in the data folder can
+// be imported and is valid. The list of files is discovered by walking the
+// embedded filesystem so that new folders and new snippets are covered without
+// having to remember to add them here.
 func TestImportStatement(t *testing.T) {
-	type testCase struct {
-		err        error
-		name       string
-		importPath string
-	}
+	var importPaths []string
 
-	var tests []testCase
-
-	for _, folderName := range []string{
-		"apps",
-		"bots",
-		"common",
-		"crawlers",
-		"meta",
-	} {
-		if err := fs.WalkDir(data.BotPolicies, folderName, func(path string, d fs.DirEntry, err error) error {
-			if err != nil {
-				return err
-			}
-			if d.IsDir() {
-				return nil
-			}
-			if d.Name() == "README.md" {
-				return nil
-			}
-
-			tests = append(tests, testCase{
-				name:       "(data)/" + path,
-				importPath: "(data)/" + path,
-				err:        nil,
-			})
-
+	if err := fs.WalkDir(data.BotPolicies, ".", func(path string, d fs.DirEntry, err error) error {
+		switch {
+		case err != nil:
+			return err
+		case d.IsDir():
 			return nil
-		}); err != nil {
-			t.Fatal(err)
+		case path == "botPolicies.yaml": // an entire config, not a list of bots
+			return nil
 		}
+
+		switch filepath.Ext(path) {
+		case ".yaml", ".yml":
+			importPaths = append(importPaths, "(data)/"+path)
+		}
+
+		return nil
+	}); err != nil {
+		t.Fatal(err)
 	}
 
-	for _, tt := range tests {
-		t.Run(tt.name, func(t *testing.T) {
+	if len(importPaths) == 0 {
+		t.Fatal("no policy snippets found in the embedded data folder")
+	}
+
+	for _, importPath := range importPaths {
+		t.Run(importPath, func(t *testing.T) {
 			is := &ImportStatement{
-				Import: tt.importPath,
+				Import: importPath,
 			}
 
 			if err := is.Valid(); err != nil {

--- a/test/traefik/docker-compose.yaml
+++ b/test/traefik/docker-compose.yaml
@@ -1,6 +1,6 @@
 services:
   traefik:
-    image: traefik:v3.3
+    image: reg.xeiaso.net/library/traefik:v3.3
     restart: always
     ports:
       - 8080:80


### PR DESCRIPTION
Automatically verify correct parsing of everything in `(data)`. While doing post-release checks on v1.26.1, I discovered that I incorrectly merged `(data)/services/updown.yaml` in such a way that it became syntactically invalid. This has been mended and multiple layers of CI have been put into place to make sure that `(data)` entries are syntactically and semantically valid.

<!--
delete me and describe your change here, give enough context for a maintainer to understand what and why

See https://github.com/TecharoHQ/anubis/blob/main/CONTRIBUTING.md for more information
-->

Checklist:

- [x] Added a description of the changes to the `[Unreleased]` section of docs/docs/CHANGELOG.md
- [x] Added test cases to [the relevant parts of the codebase](https://github.com/TecharoHQ/anubis/blob/main/CONTRIBUTING.md)
- [x] Ran integration tests `npm run test:integration` (unsupported on Windows, please use WSL)
- [x] All of my commits have [verified signatures](https://anubis.techaro.lol/docs/developer/signed-commits)
