### PR TITLE
chore(default-config): allowlist arquivo.pt crawler

### DIFF
--- a/.vscode/project-words.txt
+++ b/.vscode/project-words.txt
@@ -21,6 +21,7 @@ APNICRANDNETAU
 Applebot
 archlinux
 arpa
+arquivo
 Asahi
 asnc
 asnchecker

--- a/data/botPolicies.yaml
+++ b/data/botPolicies.yaml
@@ -37,6 +37,7 @@ bots:
   #   - Kagi
   #   - Marginalia
   #   - Mojeek
+  #   - Arquivo.pt
   - import: (data)/crawlers/_allow-good.yaml
   # Challenge Firefox AI previews
   - import: (data)/clients/x-firefox-ai.yaml

--- a/data/crawlers/_allow-good.yaml
+++ b/data/crawlers/_allow-good.yaml
@@ -10,3 +10,4 @@
 - import: (data)/crawlers/commoncrawl.yaml
 - import: (data)/crawlers/wikimedia-citoid.yaml
 - import: (data)/crawlers/yandexbot.yaml
+- import: (data)/crawlers/arquivo-pt.yaml

--- a/data/crawlers/arquivo-pt.yaml
+++ b/data/crawlers/arquivo-pt.yaml
@@ -1,0 +1,7 @@
+- name: arquivo-pt
+  action: ALLOW
+  # https://ipinfo.io/194.210.235.0
+  remote_addresses: ["194.210.235.0/26"]
+  # Not matching on the "Arquivo-web-crawler" user agent regex on purpose: it is
+  # also used by Arquivo.pt's on-demand "Archive Page Now" service, and allow-listing
+  # that user agent would break it.

--- a/docs/docs/CHANGELOG.md
+++ b/docs/docs/CHANGELOG.md
@@ -13,6 +13,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 <!-- This changes the project to: -->
 
+- Allow [Arquivo.pt](https://arquivo.pt), the Portuguese web archive, by default via its crawling network
+
 ## v1.26.2: Papalymo Totolymo: Echo 2
 
 - Automatically verify correct parsing of everything in `(data)`. While doing post-release checks on v1.26.1, I discovered that I incorrectly merged `(data)/services/updown.yaml` in such a way that it became syntactically invalid. This has been mended and multiple layers of CI have been put into place to make sure that `(data)` entries are syntactically and semantically valid.


### PR DESCRIPTION
Arquivo.pt is Portugal's national web archive. Add its crawling network to the default allow-list so Anubis deployments don't challenge/block its crawler.

Deliberately network-only (no user_agent_regex), same shape as the **Internet Archive** entry.

Arquivo.pt's crawler user agent string **`Arquivo-web-crawler`** isn't enough to allow because Arquivo.pt has a on-demand "Archive Page Now" service, similar to the Internet Archive Save Page Now service. The "Archive Page Now" service uses the pywb record mode that isn't compatible with Anubis.

Checklist:

- [X] Added a description of the changes to the `[Unreleased]` section of docs/docs/CHANGELOG.md
- [ ] Added test cases to [the relevant parts of the codebase] (https://github.com/TecharoHQ/anubis/blob/main/CONTRIBUTING.md) - **didn't do it because is just data configurations**.
- [x] Ran integration tests `npm run test:integration` (unsupported on Windows, please use WSL)
- [x] All of my commits have [verified signatures](https://anubis.techaro.lol/docs/developer/signed-commits)


References:
- https://help.archive.org/help/save-pages-in-the-wayback-machine/
- https://arquivo.pt/services/archivepagenow
- https://sobre.arquivo.pt/en/help/crawling-and-archiving-web-content/
- https://github.com/arquivo/pwa-technologies/issues/1580
- https://www.rcaap.pt/ - other FCCN project that have started to use Anubis, the reason that Arquivo.pt team have found this issue.
