### PR TITLE
Update javascript_required because a no-JS solution is apparently ready

### DIFF
--- a/docs/docs/CHANGELOG.md
+++ b/docs/docs/CHANGELOG.md
@@ -13,6 +13,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 <!-- This changes the project to: -->
 
+- Update the `javascript_required` message to mention the no-JS Meta Refresh challenge option.
+
 ## v1.26.0-pre1
 
 - Patch [GHSA-6wcg-mqvh-fcvg](https://github.com/TecharoHQ/anubis/security/advisories/GHSA-6wcg-mqvh-fcvg) by containing subrequest logic to Anubis instances in subrequest mode.

--- a/lib/localization/locales/en.json
+++ b/lib/localization/locales/en.json
@@ -15,7 +15,7 @@
   "go_home": "Go home",
   "contact_webmaster": "or if you believe you should not be blocked, please contact the webmaster at",
   "connection_security": "Please wait a moment while we ensure the security of your connection.",
-  "javascript_required": "Sadly, you must enable JavaScript to get past this challenge. This is required because AI companies have changed the social contract around how website hosting works. A no-JS solution is a work-in-progress.",
+  "javascript_required": "Sadly, you must enable JavaScript to get past this challenge. This is required because the administrator of this website decided to discriminate against some users by not enabling the no-JS Meta Refresh challenge.",
   "benchmark_requires_js": "Running the benchmark tool requires JavaScript to be enabled.",
   "difficulty": "Difficulty:",
   "algorithm": "Algorithm:",


### PR DESCRIPTION
Apparently the text is no longer relevant since #623 has been merged. `Assisted-by: GPT-5 via Codex` because you seem to like slop.

Checklist:

- [x] Added a description of the changes to the `[Unreleased]` section of docs/docs/CHANGELOG.md
- [ ] Added test cases to [the relevant parts of the codebase](https://github.com/TecharoHQ/anubis/blob/main/CONTRIBUTING.md)
- [x] Ran integration tests `npm run test:integration` (unsupported on Windows, please use WSL)
- [x] All of my commits have [verified signatures](https://anubis.techaro.lol/docs/developer/signed-commits)
