### PR TITLE
fix(lib): rename cookies based on settings

### DIFF
--- a/docs/docs/CHANGELOG.md
+++ b/docs/docs/CHANGELOG.md
@@ -11,11 +11,11 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
-- Update Bulgarian locale ([#1708](https://github.com/TecharoHQ/anubis/pull/1708))
-
 <!-- This changes the project to: -->
 
 - Add Basque (eu) localization.
+- Rename cookies based on cookie settings.
+- Update Bulgarian locale ([#1708](https://github.com/TecharoHQ/anubis/pull/1708))
 - Enabled the Partitioned flag on cookies by default ([#1701](https://github.com/TecharoHQ/anubis/issues/1701)).
 
 ## v1.27.0-pre2: Moenbryda Wilfsunnwyn

--- a/internal/test/playwright_test.go
+++ b/internal/test/playwright_test.go
@@ -25,6 +25,7 @@ import (
 	"os"
 	"os/exec"
 	"strconv"
+	"strings"
 	"testing"
 	"time"
 
@@ -401,9 +402,11 @@ func TestPlaywrightWithBasePrefix(t *testing.T) {
 				pwFail(t, page, "could not get cookies: %v", err)
 			}
 
+			// The cookie name has a suffix that is derived from the cookie
+			// settings, so match on the prefix only.
 			var found bool
 			for _, cookie := range cookies {
-				if cookie.Name == anubis.CookieName {
+				if strings.HasPrefix(cookie.Name, anubis.CookieName+"-") {
 					found = true
 					if cookie.Path != basePrefix+"/" {
 						t.Errorf("cookie path is wrong, wanted %s, got: %s", basePrefix+"/", cookie.Path)

--- a/lib/anubis.go
+++ b/lib/anubis.go
@@ -282,7 +282,7 @@ func (s *Server) maybeReverseProxy(w http.ResponseWriter, r *http.Request, httpS
 		return
 	}
 
-	ckie, err := r.Cookie(anubis.CookieName)
+	ckie, err := s.getCookie(r, anubis.CookieName)
 	if err != nil {
 		lg.DebugContext(r.Context(), "cookie not found", "path", r.URL.Path)
 		s.ClearCookie(w, CookieOpts{Path: cookiePath, Host: r.Host})
@@ -523,7 +523,7 @@ func (s *Server) PassChallenge(w http.ResponseWriter, r *http.Request) {
 		cookiePath = strings.TrimSuffix(anubis.BasePrefix, "/") + "/"
 	}
 
-	if _, err := r.Cookie(anubis.TestCookieName); errors.Is(err, http.ErrNoCookie) {
+	if _, err := s.getCookie(r, anubis.TestCookieName); errors.Is(err, http.ErrNoCookie) {
 		s.ClearCookie(w, CookieOpts{Path: cookiePath, Host: r.Host})
 		s.ClearCookie(w, CookieOpts{Name: anubis.TestCookieName, Host: r.Host})
 		lg.WarnContext(r.Context(), "user has cookies disabled, this is not an anubis bug")

--- a/lib/anubis_test.go
+++ b/lib/anubis_test.go
@@ -369,16 +369,18 @@ func TestCookieSettings(t *testing.T) {
 				t.Errorf("wanted %d, got: %d", http.StatusFound, resp.StatusCode)
 			}
 
+			wantCookieName := srv.cookieName(anubis.CookieName)
+
 			var ckie *http.Cookie
 			for _, cookie := range resp.Cookies() {
 				t.Logf("%#v", cookie)
-				if cookie.Name == anubis.CookieName {
+				if cookie.Name == wantCookieName {
 					ckie = cookie
 					break
 				}
 			}
 			if ckie == nil {
-				t.Errorf("Cookie %q not found", anubis.CookieName)
+				t.Errorf("Cookie %q not found", wantCookieName)
 				return
 			}
 
@@ -590,15 +592,17 @@ func TestBasePrefix(t *testing.T) {
 			}
 
 			// Check cookie path
+			wantCookieName := srv.cookieName(anubis.CookieName)
+
 			var ckie *http.Cookie
 			for _, cookie := range resp.Cookies() {
-				if cookie.Name == anubis.CookieName {
+				if cookie.Name == wantCookieName {
 					ckie = cookie
 					break
 				}
 			}
 			if ckie == nil {
-				t.Errorf("Cookie %q not found", anubis.CookieName)
+				t.Errorf("Cookie %q not found", wantCookieName)
 				return
 			}
 
@@ -896,7 +900,7 @@ func TestChallengeFor_ErrNotFound(t *testing.T) {
 	t.Run("make sure new test cookie is issued", func(t *testing.T) {
 		found := false
 		for _, cookie := range resp.Cookies() {
-			if cookie.Name == anubis.TestCookieName {
+			if cookie.Name == srv.cookieName(anubis.TestCookieName) {
 				if cookie.Value == wrongCookie {
 					t.Error("a new challenge cookie should be issued")
 				}
@@ -1075,7 +1079,7 @@ func TestPassChallengeNilRuleChallengeFallback(t *testing.T) {
 	req.URL.RawQuery = q.Encode()
 	req.Header.Set("X-Real-Ip", "203.0.113.4")
 	req.Header.Set("User-Agent", "NilChallengeTester/1.0")
-	req.AddCookie(&http.Cookie{Name: anubis.TestCookieName, Value: chall.ID})
+	req.AddCookie(&http.Cookie{Name: srv.cookieName(anubis.TestCookieName), Value: chall.ID})
 
 	rr := httptest.NewRecorder()
 

--- a/lib/http.go
+++ b/lib/http.go
@@ -3,7 +3,9 @@ package lib
 import (
 	"bytes"
 	"compress/gzip"
+	"crypto/sha256"
 	"encoding/base64"
+	"encoding/hex"
 	"errors"
 	"fmt"
 	"math/rand"
@@ -60,6 +62,21 @@ type CookieOpts struct {
 	Expiry time.Duration
 }
 
+func (s *Server) cookieName(base string) string {
+	h := sha256.Sum256(fmt.Appendf(nil, "%t|%t|%t|%d|%s|%t|%s",
+		s.opts.CookieHttpOnly, s.opts.CookieSecure, s.opts.CookiePartitioned,
+		s.opts.CookieSameSite, s.opts.CookieDomain, s.opts.CookieDynamicDomain,
+		anubis.BasePrefix))
+	return base + "-" + hex.EncodeToString(h[:4])
+}
+
+// getCookie reads the cookie named base from the request. It applies the same
+// settings suffix that SetCookie applies, so that cookies written with other
+// settings are ignored.
+func (s *Server) getCookie(r *http.Request, base string) (*http.Cookie, error) {
+	return r.Cookie(s.cookieName(base))
+}
+
 func (s *Server) SetCookie(w http.ResponseWriter, cookieOpts CookieOpts) {
 	var domain = s.opts.CookieDomain
 	var name = anubis.CookieName
@@ -87,7 +104,7 @@ func (s *Server) SetCookie(w http.ResponseWriter, cookieOpts CookieOpts) {
 	}
 
 	http.SetCookie(w, &http.Cookie{
-		Name:        name,
+		Name:        s.cookieName(name),
 		Value:       cookieOpts.Value,
 		Expires:     time.Now().Add(cookieOpts.Expiry),
 		SameSite:    sameSite,
@@ -121,7 +138,7 @@ func (s *Server) ClearCookie(w http.ResponseWriter, cookieOpts CookieOpts) {
 	}
 
 	http.SetCookie(w, &http.Cookie{
-		Name:        name,
+		Name:        s.cookieName(name),
 		Value:       "",
 		MaxAge:      -1,
 		Expires:     time.Now().Add(-1 * time.Minute),

--- a/lib/http_test.go
+++ b/lib/http_test.go
@@ -41,6 +41,8 @@ func TestSetCookie(t *testing.T) {
 			srv := spawnAnubis(t, tt.options)
 			rw := httptest.NewRecorder()
 
+			tt.cookieName = srv.cookieName(tt.cookieName)
+
 			srv.SetCookie(rw, CookieOpts{Value: "test", Host: tt.host})
 
 			resp := rw.Result()
@@ -71,8 +73,8 @@ func TestClearCookie(t *testing.T) {
 
 	ckie := cookies[0]
 
-	if ckie.Name != anubis.CookieName {
-		t.Errorf("wanted cookie named %q, got cookie named %q", anubis.CookieName, ckie.Name)
+	if want := srv.cookieName(anubis.CookieName); ckie.Name != want {
+		t.Errorf("wanted cookie named %q, got cookie named %q", want, ckie.Name)
 	}
 
 	if ckie.MaxAge != -1 {
@@ -96,8 +98,8 @@ func TestClearCookieWithDomain(t *testing.T) {
 
 	ckie := cookies[0]
 
-	if ckie.Name != anubis.CookieName {
-		t.Errorf("wanted cookie named %q, got cookie named %q", anubis.CookieName, ckie.Name)
+	if want := srv.cookieName(anubis.CookieName); ckie.Name != want {
+		t.Errorf("wanted cookie named %q, got cookie named %q", want, ckie.Name)
 	}
 
 	if ckie.MaxAge != -1 {
@@ -121,8 +123,8 @@ func TestClearCookieWithDynamicDomain(t *testing.T) {
 
 	ckie := cookies[0]
 
-	if ckie.Name != anubis.CookieName {
-		t.Errorf("wanted cookie named %q, got cookie named %q", anubis.CookieName, ckie.Name)
+	if want := srv.cookieName(anubis.CookieName); ckie.Name != want {
+		t.Errorf("wanted cookie named %q, got cookie named %q", want, ckie.Name)
 	}
 
 	if ckie.Domain != "xeiaso.net" {


### PR DESCRIPTION
Cookies are horrible: a rant by Xe Iaso.

Cookies are horrible. When cookies are sent from server to client, they include a number of settings that I mistakenly let administrators control. Turns out that when the browser stores them, they uniquely identify cookies by the combination of both name and settings. These settings are not sent back to the server upon requests. As a result, if any administator changes any cookie setting without changing the cookie name, the client sends two cookies. This is not good because the server tries to clear the errant cookie, but the client discards that because it doesn't match what the server sent.

To fix this, cookies are now dynamically renamed based on cookie settings. This behaviour cannot be disabled.

Ref: #1797
Ref: #1701

<!--
delete me and describe your change here, give enough context for a maintainer to understand what and why

See https://github.com/TecharoHQ/anubis/blob/main/CONTRIBUTING.md for more information
-->

Checklist:

- [x] Added a description of the changes to the `[Unreleased]` section of docs/docs/CHANGELOG.md
- [x] Added test cases to [the relevant parts of the codebase](https://github.com/TecharoHQ/anubis/blob/main/CONTRIBUTING.md)
- [x] Ran integration tests `npm run test:integration` (unsupported on Windows, please use WSL)
- [x] All of my commits have [verified signatures](https://anubis.techaro.lol/docs/developer/signed-commits)
