### PR TITLE
feat(honeypot): write honeypot IP addresses to a log file

### DIFF
--- a/data/botPolicies.yaml
+++ b/data/botPolicies.yaml
@@ -116,6 +116,10 @@ honeypot:
   ## Currently the only supported implementation is the naive method.
   ## See https://anubis.techaro.lol/docs/admin/honeypot/overview#implementation-notes for more information
   implementation: naive
+  ## Setting ip_log_file makes Anubis log IP addresses that hit honeypot URLs to a file.
+  ## Anubis writes to this file either once per minute or after Anubis records 32
+  ## kilobytes of IP addresses, whichever happens first.
+  #ip_log_file: ./var/honeypot.addrs
 
 # #
 # impressum:

--- a/docs/docs/CHANGELOG.md
+++ b/docs/docs/CHANGELOG.md
@@ -13,6 +13,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 <!-- This changes the project to: -->
 
+- Make the honeypot feature log detected addresses to the disk every minute when `honeypot.ip_log_file` is set. See the [IP address logging](./admin/honeypot/overview.mdx#ip-address-logging) section for more information.
 - Add Basque (eu) localization.
 - Rename cookies based on cookie settings.
 - Update Bulgarian locale ([#1708](https://github.com/TecharoHQ/anubis/pull/1708))

--- a/docs/docs/admin/honeypot/overview.mdx
+++ b/docs/docs/admin/honeypot/overview.mdx
@@ -53,4 +53,25 @@ Right now Anubis assigns 30 weight points if the following criteria are met:
 - A client's User-Agent has been observed in the dataset poisoning maze at least 25 times.
 - The network-clamped IP address (/24 for IPv4 and /48 for IPv6) has been observed in the dataset poisoning maze at least 25 times.
 
-Additionally, when any given client by both User-Agent and network-clamped IP address has been observed, Anubis will emit log lines warning about it so that administrative action can be taken up to and including [filing abuse reports with the network owner](/blog/2025/file-abuse-reports).
+When any given client by both User-Agent and network-clamped IP address has been observed, Anubis will emit log lines warning about it so that administrative action can be taken up to and including [filing abuse reports with the network owner](/blog/2025/file-abuse-reports).
+
+### IP address logging
+
+Anubis' honeypot feature can log IP addresses to a file. These logs let you configure fail2ban pipelines or integrate with other software to block bot traffic (eg: Panorama).
+
+To use this feature:
+
+- Anubis must have access to storage it can write to.
+- The backing filesystem must support writes, seeking, and truncation.
+- The Anubis user must have write permissions to the log file.
+
+Configure this log file in the `honeypot` section of your [policy file](../policies.mdx):
+
+```yaml
+honeypot:
+  enabled: true
+  implementation: naive
+  ip_log_file: /data/anubis/honeypot.addrs
+```
+
+Anubis collects the IP addresses that hit the honeypot feature continuously and buffers them into memory. Anubis writes collected IP addresses every minute or when Anubis collects 32 kilobytes of addresses, whichever happens first. Once the file gets bigger than 64 kilobytes, the file is reset to avoid infinite growth.

--- a/go.mod
+++ b/go.mod
@@ -29,6 +29,7 @@ require (
 	github.com/testcontainers/testcontainers-go v0.43.0
 	go.etcd.io/bbolt v1.5.0
 	golang.org/x/net v0.56.0
+	golang.org/x/sync v0.21.0
 	golang.org/x/sys v0.46.0
 	golang.org/x/text v0.38.0
 	google.golang.org/grpc v1.81.1
@@ -186,7 +187,6 @@ require (
 	golang.org/x/exp/typeparams v0.0.0-20250718183923-645b1fa84792 // indirect
 	golang.org/x/mod v0.36.0 // indirect
 	golang.org/x/oauth2 v0.36.0 // indirect
-	golang.org/x/sync v0.21.0 // indirect
 	golang.org/x/telemetry v0.0.0-20260508192327-42602be52be6 // indirect
 	golang.org/x/term v0.44.0 // indirect
 	golang.org/x/tools v0.45.0 // indirect

--- a/internal/bundler/bundler.go
+++ b/internal/bundler/bundler.go
@@ -1,0 +1,407 @@
+// Copyright 2016 Google LLC.
+// Use of this source code is governed by a BSD-style
+// license that can be found in the LICENSE file.
+
+// Package bundler supports bundling (batching) of items. Bundling amortizes an
+// action with fixed costs over multiple items. For example, if an API provides
+// an RPC that accepts a list of items as input, but clients would prefer
+// adding items one at a time, then a Bundler can accept individual items from
+// the client and bundle many of them into a single RPC.
+//
+// This package is experimental and subject to change without notice.
+package bundler
+
+import (
+	"context"
+	"errors"
+	"sync"
+	"time"
+
+	"golang.org/x/sync/semaphore"
+)
+
+type mode int
+
+const (
+	DefaultDelayThreshold        = time.Second
+	DefaultBundleHandlerDeadline = time.Minute
+	DefaultBundleCountThreshold  = 10
+	DefaultBundleByteThreshold   = 1e6 // 1M
+	DefaultBufferedByteLimit     = 1e9 // 1G
+)
+
+const (
+	none mode = iota
+	add
+	addWait
+)
+
+var (
+	// ErrOverflow indicates that Bundler's stored bytes exceeds its BufferedByteLimit.
+	ErrOverflow = errors.New("bundler: reached buffered byte limit")
+
+	// ErrOversizedItem indicates that an item's size exceeds the maximum bundle size.
+	ErrOversizedItem = errors.New("bundler: item size exceeds bundle byte limit")
+
+	// errMixedMethods indicates that mutually exclusive methods has been
+	// called subsequently.
+	errMixedMethods = errors.New("bundler: calls to Add and AddWait cannot be mixed")
+)
+
+// A Bundler collects items added to it into a bundle until the bundle
+// exceeds a given size, then calls a user-provided function to handle the
+// bundle.
+//
+// The exported fields are only safe to modify prior to the first call to Add
+// or AddWait.
+type Bundler[T any] struct {
+	// Starting from the time that the first message is added to a bundle, once
+	// this delay has passed, handle the bundle. The default is DefaultDelayThreshold.
+	DelayThreshold time.Duration
+
+	// Once a bundle has this many items, handle the bundle. Since only one
+	// item at a time is added to a bundle, no bundle will exceed this
+	// threshold, so it also serves as a limit. The default is
+	// DefaultBundleCountThreshold.
+	BundleCountThreshold int
+
+	// Once the number of bytes in current bundle reaches this threshold, handle
+	// the bundle. The default is DefaultBundleByteThreshold. This triggers handling,
+	// but does not cap the total size of a bundle.
+	BundleByteThreshold int
+
+	// The maximum size of a bundle, in bytes. Zero means unlimited.
+	BundleByteLimit int
+
+	// The maximum number of bytes that the Bundler will keep in memory before
+	// returning ErrOverflow. The default is DefaultBufferedByteLimit.
+	BufferedByteLimit int
+
+	// The maximum number of handler invocations that can be running at once.
+	// The default is 1.
+	HandlerLimit int
+
+	// ContextDeadline is the deadline for the context attached to bundle handling.
+	ContextDeadline time.Duration
+
+	handler func(context.Context, []T) // called to handle a bundle
+
+	mu           sync.Mutex          // guards access to fields below
+	flushTimer   *time.Timer         // implements DelayThreshold
+	handlerCount int                 // # of bundles currently being handled (i.e. handler is invoked on them)
+	sem          *semaphore.Weighted // enforces BufferedByteLimit
+	semOnce      sync.Once           // guards semaphore initialization
+	// The current bundle we're adding items to. Not yet in the queue.
+	// Appended to the queue once the flushTimer fires or the bundle
+	// thresholds/limits are reached. If curBundle is nil and tail is
+	// not, we first try to add items to tail. Once tail is full or handled,
+	// we create a new curBundle for the incoming item.
+	curBundle *bundle[T]
+	// The next bundle in the queue to be handled. Nil if the queue is
+	// empty.
+	head *bundle[T]
+	// The last bundle in the queue to be handled. Nil if the queue is
+	// empty. If curBundle is nil and tail isn't, we attempt to add new
+	// items to the tail until if becomes full or has been passed to the
+	// handler.
+	tail      *bundle[T]
+	curFlush  *sync.WaitGroup // counts outstanding bundles since last flush
+	prevFlush chan bool       // signal used to wait for prior flush
+
+	// The first call to Add or AddWait, mode will be add or addWait respectively.
+	// If there wasn't call yet then mode is none.
+	mode mode
+	// TODO: consider alternative queue implementation for head/tail bundle. see:
+	// https://code-review.googlesource.com/c/google-api-go-client/+/47991/4/support/bundler/bundler.go#74
+}
+
+// A bundle is a group of items that were added individually and will be passed
+// to a handler as a slice.
+type bundle[T any] struct {
+	items []T             // slice of T
+	size  int             // size in bytes of all items
+	next  *bundle[T]      // bundles are handled in order as a linked list queue
+	flush *sync.WaitGroup // the counter that tracks flush completion
+}
+
+// add appends item to this bundle and increments the total size. It requires
+// that b.mu is locked.
+func (bu *bundle[T]) add(item T, size int) {
+	bu.items = append(bu.items, item)
+	bu.size += size
+}
+
+// New creates a new Bundler.
+//
+// handler is a function that will be called on each bundle. If itemExample is
+// of type T, the argument to handler is of type []T. handler is always called
+// sequentially for each bundle, and never in parallel.
+//
+// Configure the Bundler by setting its thresholds and limits before calling
+// any of its methods.
+func New[T any](handler func(context.Context, []T)) *Bundler[T] {
+	b := &Bundler[T]{
+		DelayThreshold:       DefaultDelayThreshold,
+		BundleCountThreshold: DefaultBundleCountThreshold,
+		BundleByteThreshold:  DefaultBundleByteThreshold,
+		BufferedByteLimit:    DefaultBufferedByteLimit,
+		HandlerLimit:         1,
+
+		handler:  handler,
+		curFlush: &sync.WaitGroup{},
+	}
+	return b
+}
+
+func (b *Bundler[T]) initSemaphores() {
+	// Create the semaphores lazily, because the user may set limits
+	// after NewBundler.
+	b.semOnce.Do(func() {
+		b.sem = semaphore.NewWeighted(int64(b.BufferedByteLimit))
+	})
+}
+
+// enqueueCurBundle moves curBundle to the end of the queue. The bundle may be
+// handled immediately if we are below HandlerLimit. It requires that b.mu is
+// locked.
+func (b *Bundler[T]) enqueueCurBundle() {
+	// We don't require callers to check if there is a pending bundle. It
+	// may have already been appended to the queue. If so, return early.
+	if b.curBundle == nil {
+		return
+	}
+	// If we are below the HandlerLimit, the queue must be empty. Handle
+	// immediately with a new goroutine.
+	if b.handlerCount < b.HandlerLimit {
+		b.handlerCount++
+		go b.handle(b.curBundle)
+	} else if b.tail != nil {
+		// There are bundles on the queue, so append to the end
+		b.tail.next = b.curBundle
+		b.tail = b.curBundle
+	} else {
+		// The queue is empty, so initialize the queue
+		b.head = b.curBundle
+		b.tail = b.curBundle
+	}
+	b.curBundle = nil
+	if b.flushTimer != nil {
+		b.flushTimer.Stop()
+		b.flushTimer = nil
+	}
+}
+
+// setMode sets the state of Bundler's mode. If mode was defined before
+// and passed state is different from it then return an error.
+func (b *Bundler[T]) setMode(m mode) error {
+	b.mu.Lock()
+	defer b.mu.Unlock()
+	if b.mode == m || b.mode == none {
+		b.mode = m
+		return nil
+	}
+	return errMixedMethods
+}
+
+// canFit returns true if bu can fit an additional item of size bytes based
+// on the limits of Bundler b.
+func (b *Bundler[T]) canFit(bu *bundle[T], size int) bool {
+	return (b.BundleByteLimit <= 0 || bu.size+size <= b.BundleByteLimit) &&
+		(b.BundleCountThreshold <= 0 || len(bu.items) < b.BundleCountThreshold)
+}
+
+// Add adds item to the current bundle. It marks the bundle for handling and
+// starts a new one if any of the thresholds or limits are exceeded.
+// The type of item must be assignable to the itemExample parameter of the NewBundler
+// method, otherwise there will be a panic.
+//
+// If the item's size exceeds the maximum bundle size (Bundler.BundleByteLimit), then
+// the item can never be handled. Add returns ErrOversizedItem in this case.
+//
+// If adding the item would exceed the maximum memory allowed
+// (Bundler.BufferedByteLimit) or an AddWait call is blocked waiting for
+// memory, Add returns ErrOverflow.
+//
+// Add never blocks.
+func (b *Bundler[T]) Add(item T, size int) error {
+	if err := b.setMode(add); err != nil {
+		return err
+	}
+	// If this item exceeds the maximum size of a bundle,
+	// we can never send it.
+	if b.BundleByteLimit > 0 && size > b.BundleByteLimit {
+		return ErrOversizedItem
+	}
+
+	// If adding this item would exceed our allotted memory
+	// footprint, we can't accept it.
+	// (TryAcquire also returns false if anything is waiting on the semaphore,
+	// so calls to Add and AddWait shouldn't be mixed.)
+	b.initSemaphores()
+	if !b.sem.TryAcquire(int64(size)) {
+		return ErrOverflow
+	}
+
+	b.mu.Lock()
+	defer b.mu.Unlock()
+	return b.add(item, size)
+}
+
+// add adds item to the tail of the bundle queue or curBundle depending on space
+// and nil-ness (see inline comments). It marks curBundle for handling (by
+// appending it to the queue) if any of the thresholds or limits are exceeded.
+// curBundle is lazily initialized. It requires that b.mu is locked.
+func (b *Bundler[T]) add(item T, size int) error {
+	// If we don't have a curBundle, see if we can add to the queue tail.
+	if b.tail != nil && b.curBundle == nil && b.canFit(b.tail, size) {
+		b.tail.add(item, size)
+		return nil
+	}
+
+	// If we can't fit in the existing curBundle, move it onto the queue.
+	if b.curBundle != nil && !b.canFit(b.curBundle, size) {
+		b.enqueueCurBundle()
+	}
+
+	// Create a curBundle if we don't have one.
+	if b.curBundle == nil {
+		b.curFlush.Add(1)
+		b.curBundle = &bundle[T]{
+			items: []T{},
+			flush: b.curFlush,
+		}
+	}
+
+	// Add the item.
+	b.curBundle.add(item, size)
+
+	// If curBundle is ready for handling, move it to the queue.
+	if b.curBundle.size >= b.BundleByteThreshold ||
+		len(b.curBundle.items) == b.BundleCountThreshold {
+		b.enqueueCurBundle()
+	}
+
+	// If we created a new bundle and it wasn't immediately handled, set a timer
+	if b.curBundle != nil && b.flushTimer == nil {
+		b.flushTimer = time.AfterFunc(b.DelayThreshold, b.tryHandleBundles)
+	}
+
+	return nil
+}
+
+// tryHandleBundles is the timer callback that handles or queues any current
+// bundle after DelayThreshold time, even if the bundle isn't completely full.
+func (b *Bundler[T]) tryHandleBundles() {
+	b.mu.Lock()
+	b.enqueueCurBundle()
+	b.mu.Unlock()
+}
+
+// next returns the next bundle that is ready for handling and removes it from
+// the internal queue. It requires that b.mu is locked.
+func (b *Bundler[T]) next() *bundle[T] {
+	if b.head == nil {
+		return nil
+	}
+	out := b.head
+	b.head = b.head.next
+	if b.head == nil {
+		b.tail = nil
+	}
+	out.next = nil
+	return out
+}
+
+// handle calls the user-specified handler on the given bundle. handle is
+// intended to be run as a goroutine. After the handler returns, we update the
+// byte total. handle continues processing additional bundles that are ready.
+// If no more bundles are ready, the handler count is decremented and the
+// goroutine ends.
+func (b *Bundler[T]) handle(bu *bundle[T]) {
+	for bu != nil {
+		ctx, cancel := context.WithTimeout(context.Background(), b.ContextDeadline)
+		b.handler(ctx, bu.items)
+		cancel()
+		bu = b.postHandle(bu)
+	}
+}
+
+func (b *Bundler[T]) postHandle(bu *bundle[T]) *bundle[T] {
+	b.mu.Lock()
+	defer b.mu.Unlock()
+
+	b.sem.Release(int64(bu.size))
+	bu.flush.Done()
+
+	bu = b.next()
+	if bu == nil {
+		b.handlerCount--
+	}
+	return bu
+}
+
+// AddWait adds item to the current bundle. It marks the bundle for handling and
+// starts a new one if any of the thresholds or limits are exceeded.
+//
+// If the item's size exceeds the maximum bundle size (Bundler.BundleByteLimit), then
+// the item can never be handled. AddWait returns ErrOversizedItem in this case.
+//
+// If adding the item would exceed the maximum memory allowed (Bundler.BufferedByteLimit),
+// AddWait blocks until space is available or ctx is done.
+//
+// Calls to Add and AddWait should not be mixed on the same Bundler.
+func (b *Bundler[T]) AddWait(ctx context.Context, item T, size int) error {
+	if err := b.setMode(addWait); err != nil {
+		return err
+	}
+	// If this item exceeds the maximum size of a bundle,
+	// we can never send it.
+	if b.BundleByteLimit > 0 && size > b.BundleByteLimit {
+		return ErrOversizedItem
+	}
+	// If adding this item would exceed our allotted memory footprint, block
+	// until space is available. The semaphore is FIFO, so there will be no
+	// starvation.
+	b.initSemaphores()
+	if err := b.sem.Acquire(ctx, int64(size)); err != nil {
+		return err
+	}
+
+	b.mu.Lock()
+	defer b.mu.Unlock()
+	return b.add(item, size)
+}
+
+// Flush invokes the handler for all remaining items in the Bundler and waits
+// for it to return.
+func (b *Bundler[T]) Flush() {
+	b.mu.Lock()
+
+	// If a curBundle is pending, move it to the queue.
+	b.enqueueCurBundle()
+
+	// Store a pointer to the WaitGroup that counts outstanding bundles
+	// in the current flush and create a new one to track the next flush.
+	wg := b.curFlush
+	b.curFlush = &sync.WaitGroup{}
+
+	// Flush must wait for all prior, outstanding flushes to complete.
+	// We use a channel to communicate completion between each flush in
+	// the sequence.
+	prev := b.prevFlush
+	next := make(chan bool)
+	b.prevFlush = next
+
+	b.mu.Unlock()
+
+	// Wait until the previous flush is finished.
+	if prev != nil {
+		<-prev
+	}
+
+	// Wait until this flush is finished.
+	wg.Wait()
+
+	// Allow the next flush to finish.
+	close(next)
+}

--- a/internal/bundler/bundler_test.go
+++ b/internal/bundler/bundler_test.go
@@ -26,7 +26,9 @@ func TestBundler(t *testing.T) {
 	})
 
 	for _, i := range input {
-		b.Add(i, 1)
+		if err := b.Add(i, 1); err != nil {
+			t.Fatal(err)
+		}
 	}
 
 	b.Flush()

--- a/internal/bundler/bundler_test.go
+++ b/internal/bundler/bundler_test.go
@@ -1,0 +1,37 @@
+package bundler
+
+import (
+	"context"
+	"testing"
+)
+
+func TestBundler(t *testing.T) {
+	input := []int{1, 2, 3, 4}
+	done := false
+	b := New[int](func(_ context.Context, data []int) {
+		if len(data) != 4 {
+			t.Errorf("Wanted len(data) == %d, got: %d", len(input), len(data))
+		}
+
+		sum := 0
+		const wantSum = 10
+		for _, i := range data {
+			sum += i
+		}
+
+		if sum != wantSum {
+			t.Errorf("wanted sum of inputs to be %d, got: %d", wantSum, sum)
+		}
+		done = true
+	})
+
+	for _, i := range input {
+		b.Add(i, 1)
+	}
+
+	b.Flush()
+
+	if !done {
+		t.Fatal("function wasn't called")
+	}
+}

--- a/internal/cmd/mkmsi/msi_test.go
+++ b/internal/cmd/mkmsi/msi_test.go
@@ -9,6 +9,7 @@ import (
 	"os/exec"
 	"path/filepath"
 	"regexp"
+	"runtime"
 	"slices"
 	"sort"
 	"strconv"
@@ -272,6 +273,10 @@ func componentConditions(t *testing.T, msi string) map[string]string {
 }
 
 func TestMSIContents(t *testing.T) {
+	if runtime.GOOS == "darwin" {
+		t.Skip("skipping on development machines")
+	}
+
 	msi := buildTestMSI(t, "amd64")
 
 	for _, tt := range []struct {
@@ -374,6 +379,10 @@ func TestMSIContents(t *testing.T) {
 // installed -- so a fresh install, which has a placeholder target and no
 // signing key, never starts the service.
 func TestMSIStartsServiceOnlyOnUpgrade(t *testing.T) {
+	if runtime.GOOS == "darwin" {
+		t.Skip("skipping on development machines")
+	}
+
 	msi := buildTestMSI(t, "amd64")
 
 	conditions := componentConditions(t, msi)
@@ -411,6 +420,10 @@ func TestMSIStartsServiceOnlyOnUpgrade(t *testing.T) {
 }
 
 func TestMSIArm64(t *testing.T) {
+	if runtime.GOOS == "darwin" {
+		t.Skip("skipping on development machines")
+	}
+
 	amd64 := buildTestMSI(t, "amd64")
 	arm64 := buildTestMSI(t, "arm64")
 
@@ -475,6 +488,10 @@ func extractStream(t *testing.T, msi, stream string) []byte {
 // what changes if someone swaps in a real image and the patch stops running,
 // since the stock artwork's size is fixed and different from Anubis's.
 func TestMSIInstallerImages(t *testing.T) {
+	if runtime.GOOS == "darwin" {
+		t.Skip("skipping on development machines")
+	}
+
 	msi := buildTestMSI(t, "amd64")
 
 	for _, img := range installerImages {
@@ -683,6 +700,10 @@ func requireSuminfoMatchesExceptTimestamps(t *testing.T, msi1, msi2 string) {
 // Everything else -- every other table, and every stream including the CAB
 // archive -- is required to be exactly byte-identical.
 func TestMSIReproducibleBuild(t *testing.T) {
+	if runtime.GOOS == "darwin" {
+		t.Skip("skipping on development machines")
+	}
+
 	requireTool(t, "wixl")
 	requireTool(t, "wixl-heat")
 	requireTool(t, "msiinfo")

--- a/internal/honeypot/naive/naive.go
+++ b/internal/honeypot/naive/naive.go
@@ -1,18 +1,25 @@
 package naive
 
 import (
+	"bytes"
 	"context"
 	_ "embed"
 	"fmt"
+	"io"
 	"log/slog"
 	"math"
 	"math/rand/v2"
 	"net/http"
 	"net/netip"
+	"os"
+	"slices"
+	"sort"
 	"time"
 
 	"github.com/TecharoHQ/anubis/internal"
+	"github.com/TecharoHQ/anubis/internal/bundler"
 	"github.com/TecharoHQ/anubis/internal/honeypot"
+	"github.com/TecharoHQ/anubis/lib/config"
 	"github.com/TecharoHQ/anubis/lib/policy/checker"
 	"github.com/TecharoHQ/anubis/lib/store"
 	"github.com/a-h/templ"
@@ -37,7 +44,7 @@ var titles string
 //go:embed affirmations.txt
 var affirmations string
 
-func New(st store.Interface, lg *slog.Logger) (*Impl, error) {
+func New(cfg *config.Honeypot, st store.Interface, lg *slog.Logger) (*Impl, error) {
 	affirmation, err := spintax.Parse(affirmations)
 	if err != nil {
 		return nil, fmt.Errorf("can't parse affirmations: %w", err)
@@ -53,6 +60,68 @@ func New(st store.Interface, lg *slog.Logger) (*Impl, error) {
 		return nil, fmt.Errorf("can't parse titles: %w", err)
 	}
 
+	var fout *os.File
+	var foutBundler *bundler.Bundler[string]
+
+	if cfg.IPLogFile != "" {
+		lg.InfoContext(context.Background(), "logging honeypot IP addresses", "foutName", cfg.IPLogFile)
+
+		fout, err = os.Create(cfg.IPLogFile)
+		if err != nil {
+			return nil, fmt.Errorf("can't open ip log file %q: %w", cfg.IPLogFile, err)
+		}
+
+		if _, err := fout.Seek(0, 0); err != nil {
+			return nil, fmt.Errorf("can't rewind ip log file %q: %w", cfg.IPLogFile, err)
+		}
+
+		if err := fout.Truncate(0); err != nil {
+			return nil, fmt.Errorf("can't truncate ip log file %q: %w", cfg.IPLogFile, err)
+		}
+
+		lg := lg.With("in", "foutBundler")
+
+		foutBundler = bundler.New(func(ctx context.Context, ips []string) {
+			st, err := fout.Stat()
+			if err != nil {
+				lg.ErrorContext(ctx, "can't stat ip log file", "foutName", cfg.IPLogFile, "err", err)
+				return
+			}
+
+			if st.Size() >= 65536 {
+				if _, err := fout.Seek(0, 0); err != nil {
+					lg.ErrorContext(ctx, "can't rewind ip log file", "foutName", cfg.IPLogFile, "err", err)
+					return
+				}
+
+				if err := fout.Truncate(0); err != nil {
+					lg.ErrorContext(ctx, "can't truncate ip log file", "foutName", cfg.IPLogFile, "err", err)
+					return
+				}
+			}
+
+			sort.Strings(ips)
+			ips = slices.Compact(ips)
+
+			buf := bytes.NewBuffer(nil)
+			for _, ip := range ips {
+				fmt.Fprintln(buf, ip)
+			}
+
+			if _, err := io.Copy(fout, buf); err != nil {
+				lg.ErrorContext(ctx, "can't write buffered IP addresses to output file", "foutName", cfg.IPLogFile, "err", err)
+				return
+			}
+
+			if err := fout.Sync(); err != nil {
+				lg.ErrorContext(ctx, "can't sync output file", "foutName", cfg.IPLogFile, "err", err)
+			}
+		})
+
+		foutBundler.BundleByteLimit = 32768
+		foutBundler.DelayThreshold = time.Minute
+	}
+
 	lg.Debug("initialized basic bullshit generator", "affirmations", affirmation.Count(), "bodies", body.Count(), "titles", title.Count())
 
 	return &Impl{
@@ -64,6 +133,8 @@ func New(st store.Interface, lg *slog.Logger) (*Impl, error) {
 		body:          body,
 		title:         title,
 		lg:            lg.With("component", "honeypot/naive"),
+		fout:          fout,
+		foutBundler:   foutBundler,
 	}, nil
 }
 
@@ -73,6 +144,8 @@ type Impl struct {
 	uaWeight      store.JSON[int]
 	networkWeight store.JSON[int]
 	lg            *slog.Logger
+	fout          *os.File
+	foutBundler   *bundler.Bundler[string]
 
 	affirmation, body, title spintax.Spintax
 }
@@ -148,6 +221,11 @@ func (i *Impl) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 	realIP, _ := internal.RealIP(r)
 	if !realIP.IsValid() {
 		realIP = netip.MustParseAddr(r.Header.Get("X-Real-Ip"))
+	}
+
+	if i.foutBundler != nil {
+		rip := realIP.String()
+		i.foutBundler.Add(rip, len(rip)+1) // for the newline
 	}
 
 	network, ok := internal.ClampIP(realIP)

--- a/internal/honeypot/naive/naive.go
+++ b/internal/honeypot/naive/naive.go
@@ -225,7 +225,7 @@ func (i *Impl) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 
 	if i.foutBundler != nil {
 		rip := realIP.String()
-		i.foutBundler.Add(rip, len(rip)+1) // for the newline
+		_ = i.foutBundler.Add(rip, len(rip)+1) // for the newline
 	}
 
 	network, ok := internal.ClampIP(realIP)

--- a/lib/config.go
+++ b/lib/config.go
@@ -178,7 +178,7 @@ func New(opts Options) (*Server, error) {
 	registerWithPrefix("/", http.HandlerFunc(result.maybeReverseProxyOrPage), "")
 
 	if opts.Policy.Honeypot != nil && opts.Policy.Honeypot.Enabled {
-		mazeGen, err := naive.New(result.store, result.logger)
+		mazeGen, err := naive.New(opts.Policy.Honeypot, result.store, result.logger)
 		if err == nil {
 			registerWithPrefix(anubis.APIPrefix+"honeypot/{id}/{stage}", mazeGen, http.MethodGet)
 

--- a/lib/config/honeypot.go
+++ b/lib/config/honeypot.go
@@ -10,6 +10,7 @@ var ErrInvalidHoneypotMethod = errors.New("config.Honeypot: invalid implementati
 type Honeypot struct {
 	Enabled        bool   `json:"enabled" yaml:"enabled"`
 	Implementation string `json:"implementation" yaml:"implementation"`
+	IPLogFile      string `json:"ip_log_file" yaml:"ip_log_file"`
 }
 
 func (h Honeypot) Valid() error {

--- a/test/go.mod
+++ b/test/go.mod
@@ -90,6 +90,7 @@ require (
 	go.yaml.in/yaml/v3 v3.0.4 // indirect
 	golang.org/x/exp v0.0.0-20251209150349-8475f28825e9 // indirect
 	golang.org/x/net v0.56.0 // indirect
+	golang.org/x/sync v0.21.0 // indirect
 	golang.org/x/sys v0.46.0 // indirect
 	golang.org/x/text v0.38.0 // indirect
 	google.golang.org/genproto/googleapis/api v0.0.0-20260226221140-a57be14db171 // indirect


### PR DESCRIPTION
Setting `ip_log_file` makes Anubis log IP addresses that hit honeypot pages to a file. Anubis writes to this file either once per minute or when Anubis records 32 kilobytes of IP addresses, whichever happens first.

This feature lets administrators configure fail2ban or Panorama pipelines with the honeypot maze generation.

Checklist:

- [x] Added a description of the changes to the `[Unreleased]` section of docs/docs/CHANGELOG.md
- [ ] Added test cases to [the relevant parts of the codebase](https://github.com/TecharoHQ/anubis/blob/main/CONTRIBUTING.md)
- [x] Ran integration tests `npm run test:integration` (unsupported on Windows, please use WSL)
- [x] All of my commits have [verified signatures](https://anubis.techaro.lol/docs/developer/signed-commits)
