### PR TITLE
fix(proofofwork): de-flake JavaScript loading in Google Chrome

### DIFF
--- a/docs/docs/CHANGELOG.md
+++ b/docs/docs/CHANGELOG.md
@@ -13,6 +13,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 <!-- This changes the project to: -->
 
+- JavaScript served by the `fast` challenge is loaded using [`defer`](https://www.w3schools.com/tags/att_script_defer.asp) instead of `async` ([#1782](https://github.com/TecharoHQ/anubis/issues/1782)).
+
 ## v1.27.0-pre3: Moenbryda Wilfsunnwyn
 
 - Make the honeypot feature log detected addresses to the disk every minute when `honeypot.ip_log_file` is set. See the [IP address logging](./admin/honeypot/overview.mdx#ip-address-logging) section for more information.

--- a/lib/challenge/proofofwork/proofofwork.templ
+++ b/lib/challenge/proofofwork/proofofwork.templ
@@ -11,7 +11,7 @@ templ page(localizer *localization.SimpleLocalizer) {
 		<img style="display:none;" style="width:100%;max-width:256px;" src={ anubis.BasePrefix + "/.within.website/x/cmd/anubis/static/img/happy.webp?cacheBuster=" + anubis.Version }/>
 		<p id="status">{ localizer.T("loading") }</p>
 		<p id="anubis-script-error" style="display:none;">{ localizer.T("script_load_error") }</p>
-		<script id="anubis-main" async type="module" src={ anubis.BasePrefix + "/.within.website/x/cmd/anubis/static/js/main.mjs?cacheBuster=" + anubis.Version }></script>
+		<script id="anubis-main" defer type="module" src={ anubis.BasePrefix + "/.within.website/x/cmd/anubis/static/js/main.mjs?cacheBuster=" + anubis.Version }></script>
 		@bootstrap()
 		<div id="progress" role="progressbar" aria-labelledby="status">
 			<div class="bar-inner"></div>

--- a/lib/challenge/proofofwork/proofofwork_templ.go
+++ b/lib/challenge/proofofwork/proofofwork_templ.go
@@ -86,7 +86,7 @@ func page(localizer *localization.SimpleLocalizer) templ.Component {
 		if templ_7745c5c3_Err != nil {
 			return templ_7745c5c3_Err
 		}
-		templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 5, "</p><script id=\"anubis-main\" async type=\"module\" src=\"")
+		templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 5, "</p><script id=\"anubis-main\" defer type=\"module\" src=\"")
 		if templ_7745c5c3_Err != nil {
 			return templ_7745c5c3_Err
 		}


### PR DESCRIPTION
Load JavaScript using `defer` instead of `async`. This fixes a rare race condition that can happen when Chrome finishes downloading the challenge JavaScript before finishing page rendering.

I was not able to reproduce this in testing, possibly due to my setup being incredibly low-latency.

Closes: #1782

<!--
delete me and describe your change here, give enough context for a maintainer to understand what and why

See https://github.com/TecharoHQ/anubis/blob/main/CONTRIBUTING.md for more information
-->

Checklist:

- [x] Added a description of the changes to the `[Unreleased]` section of docs/docs/CHANGELOG.md
- [ ] Added test cases to [the relevant parts of the codebase](https://github.com/TecharoHQ/anubis/blob/main/CONTRIBUTING.md)
- [x] Ran integration tests `npm run test:integration` (unsupported on Windows, please use WSL)
- [x] All of my commits have [verified signatures](https://anubis.techaro.lol/docs/developer/signed-commits)
