### PR TITLE
fix(localization): don't load manifest.json as a locale

### DIFF
--- a/docs/docs/CHANGELOG.md
+++ b/docs/docs/CHANGELOG.md
@@ -22,6 +22,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Updates IP list for DuckDuckBot ([#1810](https://github.com/TecharoHQ/anubis/pull/1810))
 - Update Huawei Cloud IP list ([#1814](https://github.com/TecharoHQ/anubis/pull/1814))
 - Add standard library rules for making Dillo less threatening to Anubis and [document how to enable them](./admin/faq.mdx#how-do-i-allow-small-internet-browsers-like-dillo-netsurf-and-pale-moon-to-bypass-anubis).
+- Fix a panic when a request asks for the undetermined language tag, such as `Accept-Language: und` ([#1776](https://github.com/TecharoHQ/anubis/issues/1776)).
 
 ## v1.27.0-pre3: Moenbryda Wilfsunnwyn
 

--- a/lib/localization/localization.go
+++ b/lib/localization/localization.go
@@ -15,6 +15,12 @@ import (
 //go:embed locales/*.json
 var localeFS embed.FS
 
+// manifestFile lists the supported languages. It is metadata, not a translation
+// catalog: go-i18n derives a locale from the file name, and "manifest" registers
+// under language.Und, which then shadows the English fallback for requests that
+// ask for "und".
+const manifestFile = "manifest.json"
+
 type LocalizationService struct {
 	bundle *i18n.Bundle
 }
@@ -39,7 +45,7 @@ func NewLocalizationService() *LocalizationService {
 
 		loadedAny := false
 		for _, entry := range entries {
-			if !entry.IsDir() && strings.HasSuffix(entry.Name(), ".json") {
+			if !entry.IsDir() && strings.HasSuffix(entry.Name(), ".json") && entry.Name() != manifestFile {
 				filePath := "locales/" + entry.Name()
 				_, err := bundle.LoadMessageFileFS(localeFS, filePath)
 				if err != nil {

--- a/lib/localization/localization_test.go
+++ b/lib/localization/localization_test.go
@@ -177,3 +177,37 @@ func TestAcceptLanguageQualityFactors(t *testing.T) {
 		})
 	}
 }
+
+func TestAcceptLanguageUndetermined(t *testing.T) {
+	service := NewLocalizationService()
+
+	testCases := []struct {
+		name           string
+		acceptLanguage string
+		expectedLang   string
+	}{
+		{"undetermined", "und", "en"},
+		{"undetermined_with_quality", "und;q=0.9", "en"},
+		{"undetermined_below_german", "de,und;q=0.9", "de"},
+		{"unknown_subtag", "xx", "en"},
+	}
+
+	for _, tc := range testCases {
+		t.Run(tc.name, func(t *testing.T) {
+			req := httptest.NewRequest("GET", "/", nil)
+			req.Header.Set("Accept-Language", tc.acceptLanguage)
+
+			sl := &SimpleLocalizer{Localizer: service.GetLocalizerFromRequest(req)}
+
+			// T uses MustLocalize, so an unresolved message panics and serving the
+			// challenge page fails. GetLang alone cannot catch that: it swallows the
+			// lookup error and reports "en" either way.
+			if got := sl.T("making_sure_not_bot"); got == "" {
+				t.Errorf("Accept-Language %q: empty translation", tc.acceptLanguage)
+			}
+			if got := sl.GetLang(); got != tc.expectedLang {
+				t.Errorf("Accept-Language %q: expected %s, got %s", tc.acceptLanguage, tc.expectedLang, got)
+			}
+		})
+	}
+}


### PR DESCRIPTION
`Accept-Language: und` panics the challenge handler.

`NewLocalizationService` loads every `locales/*.json` into the bundle, including `manifest.json`. go-i18n derives a locale from the file name, so `manifest` — which is not a language tag — registers under `language.Und`. A request whose highest priority tag is `und` then matches that entry instead of the `"en"` fallback appended in `GetLocalizerFromRequest`, the message is missing from it, and `MustLocalize` panics:

```
http: panic serving 10.0.0.1:1234: message "making_sure_not_bot" not found in language "und"
```

Skipping `manifest.json` when populating the bundle removes the bogus locale. Other unusual tags already fell back correctly — `und-US`, `mul`, `zxx`, `qaa`, and unknown subtags such as `xx` — only the exact zero tag was affected.

The test asserts through `T()` rather than `GetLang()` on purpose: `GetLang()` swallows the lookup error and reports `"en"` either way, so a test built on it would pass with and without this change. Reverting only `localization.go` makes it fail with the panic above.

Fixes #1776

Checklist:

- [x] Added a description of the changes to the `[Unreleased]` section of docs/docs/CHANGELOG.md
- [x] Added test cases to [the relevant parts of the codebase](https://github.com/TecharoHQ/anubis/blob/main/CONTRIBUTING.md)
- [ ] Ran integration tests `npm run test:integration` (unsupported on Windows, please use WSL)
- [x] All of my commits have [verified signatures](https://anubis.techaro.lol/docs/developer/signed-commits)

`npm run test`, `go vet ./...` and `staticcheck` all pass. I could not get the Playwright harness up locally: `TestPlaywrightBrowser` fails with `could not connect to remote browser: Connection closed` on unmodified `main` as well, so it looks environmental rather than related to this change.
