### PR TITLE
test(internal/test): make the Playwright suite runnable again

### DIFF
--- a/docs/docs/CHANGELOG.md
+++ b/docs/docs/CHANGELOG.md
@@ -13,6 +13,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 <!-- This changes the project to: -->
 
+- Fix `npm run test:integration` so the Playwright suite can connect to browsers and Firefox can reach the test server again.
+
 ## v1.27.0: Moenbryda Wilfsunnwyn
 
 Anubis v1.27.0 adds Windows Server support, automatically renames cookies based on settings to avoid infinite challenge loops, adds two new localizations, and more.

--- a/internal/test/playwright_test.go
+++ b/internal/test/playwright_test.go
@@ -26,6 +26,7 @@ import (
 	"os/exec"
 	"strconv"
 	"strings"
+	"syscall"
 	"testing"
 	"time"
 
@@ -159,13 +160,19 @@ func daemonize(t *testing.T, command string) {
 	cmd.Stdin = nil
 	cmd.Stderr = os.Stderr
 	cmd.Stdout = os.Stdout
+	// Run in its own process group so cleanup can reap the whole tree. Killing
+	// only sh leaves the server holding the test binary's stdout, which makes go
+	// test report "Test I/O incomplete" and fail even when every test passed.
+	cmd.SysProcAttr = &syscall.SysProcAttr{Setpgid: true}
 
 	if err := cmd.Start(); err != nil {
 		t.Fatalf("can't daemonize command: %v", err)
 	}
 
 	t.Cleanup(func() {
-		cmd.Process.Kill()
+		if err := syscall.Kill(-cmd.Process.Pid, syscall.SIGKILL); err != nil {
+			t.Logf("can't kill process group of %d: %v", cmd.Process.Pid, err)
+		}
 	})
 }
 
@@ -230,9 +237,7 @@ func TestPlaywrightBrowser(t *testing.T) {
 
 	for _, typ := range browsers {
 		t.Run(typ.Name()+"/warmup", func(t *testing.T) {
-			browser, err := typ.Connect(buildBrowserConnect(typ.Name()), playwright.BrowserTypeConnectOptions{
-				ExposeNetwork: playwright.String("<loopback>"),
-			})
+			browser, err := typ.Connect(buildBrowserConnect(typ.Name()))
 			if err != nil {
 				t.Fatalf("could not connect to remote browser: %v", err)
 			}
@@ -318,9 +323,7 @@ func TestPlaywrightWithBasePrefix(t *testing.T) {
 
 	for _, typ := range browsers {
 		t.Run(typ.Name()+"/basePrefix", func(t *testing.T) {
-			browser, err := typ.Connect(buildBrowserConnect(typ.Name()), playwright.BrowserTypeConnectOptions{
-				ExposeNetwork: playwright.String("<loopback>"),
-			})
+			browser, err := typ.Connect(buildBrowserConnect(typ.Name()))
 			if err != nil {
 				t.Fatalf("could not connect to remote browser: %v", err)
 			}
@@ -422,6 +425,12 @@ func TestPlaywrightWithBasePrefix(t *testing.T) {
 	}
 }
 
+// buildBrowserConnect returns the URL to connect to for the named browser.
+//
+// Callers pass no BrowserTypeConnectOptions: playwright-go does not implement
+// the SocksSupport channel that exposeNetwork relies on, so requesting it makes
+// the server close the connection. The browser therefore has to share the
+// host's loopback, which both supported runners do.
 func buildBrowserConnect(name string) string {
 	u, _ := url.Parse(*playwrightServer)
 
@@ -435,9 +444,7 @@ func buildBrowserConnect(name string) string {
 func executeTestCase(t *testing.T, tc testCase, typ playwright.BrowserType, anubisURL string) (action, error) {
 	deadline, _ := t.Deadline()
 
-	browser, err := typ.Connect(buildBrowserConnect(typ.Name()), playwright.BrowserTypeConnectOptions{
-		ExposeNetwork: playwright.String("<loopback>"),
-	})
+	browser, err := typ.Connect(buildBrowserConnect(typ.Name()))
 	if err != nil {
 		return "", fmt.Errorf("could not connect to remote browser: %w", err)
 	}
@@ -604,7 +611,10 @@ func spawnAnubisWithOptions(t *testing.T, basePrefix string) string {
 		t.Fatal(err)
 	}
 
-	listener, err := net.Listen("tcp", ":0")
+	// Bind loopback explicitly: binding every interface makes ts.URL the
+	// unspecified address (http://[::]:port), which Firefox refuses to navigate
+	// to with NS_ERROR_CONNECTION_REFUSED.
+	listener, err := net.Listen("tcp", "127.0.0.1:0")
 	if err != nil {
 		t.Fatalf("can't listen on random port: %v", err)
 	}


### PR DESCRIPTION
Fixes #1829. `npm run test:integration` could not pass as checked out; with this it does:

```text
ok  github.com/TecharoHQ/anubis/internal/test  103.848s
24 passed / 0 failed / 3 skipped, across chromium, firefox and webkit
```

Three independent defects, each one hiding the next:

**1. Every browser connect failed** with `could not connect to remote browser: Connection closed`, including `warmup`, so no request ever reached Anubis. playwright-go does not implement the `SocksSupport` channel that `exposeNetwork` relies on — `objectFactory.go:70` returns `nil` for it — so the server dropped the connection. Removed the three `ExposeNetwork` options. Both supported runners put the browser on the host's loopback (`npx` is local, `docker` uses `--net=host`), so the option was not buying anything; and since it never worked, nothing that used to pass stops passing.

**2. Firefox then refused the test server** with `NS_ERROR_CONNECTION_REFUSED` on `http://[::]:35943`. `net.Listen("tcp", ":0")` makes `ts.URL` the *unspecified* address. Chromium and WebKit tolerate it, Firefox does not. Now binds `127.0.0.1:0`.

**3. The suite then failed after passing.** Cleanup killed `sh` but not its children, so the daemonized Playwright server kept the test binary's stdout open:

```text
PASS
*** Test I/O incomplete 1m0s after exiting.
exec: WaitDelay expired before I/O complete
FAIL	github.com/TecharoHQ/anubis/internal/test
```

The process now runs in its own group and cleanup reaps the group. This also stops the suite leaking a Playwright server on port 9001 after every run.

Checklist:

- [x] Added a description of the changes to the `[Unreleased]` section of docs/docs/CHANGELOG.md
- [x] Added test cases to [the relevant parts of the codebase](https://github.com/TecharoHQ/anubis/blob/main/CONTRIBUTING.md) — n/a, this is a fix to the test harness itself; the suite it repairs is the test
- [x] Ran integration tests `npm run test:integration` (unsupported on Windows, please use WSL)
- [x] All of my commits have [verified signatures](https://anubis.techaro.lol/docs/developer/signed-commits)

---

<details>
<summary><b>Alternatives, and what this gives up</b></summary>

For defect 1 a dependency bump would have been preferable, but v0.6100.0 is the newest `github.com/mxschmitt/playwright-go` and still has `case "SocksSupport": return nil`, so there is nothing to bump to.

What is given up: a genuinely *remote* Playwright server — one not sharing the host's loopback — can no longer reach the test server. That configuration is mentioned in the file header comment, but it cannot have worked, because `exposeNetwork` was exactly the mechanism it needed and that mechanism closes the connection. If you want it supported later, it needs a playwright-go that implements `SocksSupport`, or binding the test server to an address the remote browser can route to.

I left the file's header comment alone rather than widen the diff; note that it still refers to `-bind` and `-anubis` flags that no longer exist.

</details>

<details>
<summary><b>How defect 1 was isolated</b></summary>

Against a plain `npx --yes playwright@1.61.1 run-server --port 9001` on the same machine:

```go
pw, _ := playwright.Run(&playwright.RunOptions{SkipInstallBrowsers: true})
const url = "ws://localhost:9001/?browser=chromium"

b, err := pw.Chromium.Connect(url)                       // OK, 149.0.7827.55
b2, err := pw.Chromium.Connect(url, playwright.BrowserTypeConnectOptions{
    ExposeNetwork: playwright.String("<loopback>"),
})                                                        // FAIL: Connection closed
```

Same result against the containerised server from `--playwright-runner=docker`. The server itself is healthy in both cases: it logs `Listening on ws://0.0.0.0:9001/` and a raw WebSocket upgrade returns `101 Switching Protocols`.

</details>

<details>
<summary><b>Note on CI</b></summary>

No workflow references `test:integration` or `TestPlaywrightBrowser`, and `npm run test` sets `SKIP_INTEGRATION=1`, so CI does not exercise this suite — which is presumably how all three defects accumulated unnoticed. Wiring it into CI is a bigger decision (runtime, browser downloads, flake budget) so I have not touched it here.

</details>
