### PR TITLE
feat(data/bots): block Cloudflare Kitesurf

### DIFF
--- a/.vscode/project-words.txt
+++ b/.vscode/project-words.txt
@@ -280,6 +280,7 @@ keypair
 keypairreloader
 KHTML
 kinda
+Kitesurf
 kpr
 KUBECONFIG
 lcj

--- a/data/bots/_deny-pathological.yaml
+++ b/data/bots/_deny-pathological.yaml
@@ -1,3 +1,4 @@
+- import: (data)/bots/cloudflare-kitesurf.yaml
 - import: (data)/bots/cloudflare-workers.yaml
 - import: (data)/bots/headless-browsers.yaml
 - import: (data)/bots/us-ai-scraper.yaml

--- a/data/bots/cloudflare-kitesurf.yaml
+++ b/data/bots/cloudflare-kitesurf.yaml
@@ -1,0 +1,11 @@
+- name: cloudflare-kitesurf
+  action: WEIGH
+  weight:
+    adjust: 15
+  expression:
+    any:
+      - '"Cdn-Loop" in headers'
+      - '"Cf-Ray" in headers'
+      - '"Cf-Ew-Via" in headers'
+      - '"Cf-Visitor" in headers'
+      - '"Cf-Worker" in headers'

--- a/docs/docs/CHANGELOG.md
+++ b/docs/docs/CHANGELOG.md
@@ -14,6 +14,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 <!-- This changes the project to: -->
 
 - Fix `npm run test:integration` so the Playwright suite can connect to browsers and Firefox can reach the test server again.
+- Add weighing rule for [Cloudflare Kitesurf](https://blog.cloudflare.com/kitesurf/). Kitesurf doesn't currently support Cookies, but it might in the future.
 
 ## v1.27.0: Moenbryda Wilfsunnwyn
 


### PR DESCRIPTION
Add weighing rule for [Cloudflare Kitesurf](https://blog.cloudflare.com/kitesurf/). Kitesurf doesn't currently support Cookies, but it might in the future.

Checklist:

- [x] Added a description of the changes to the `[Unreleased]` section of docs/docs/CHANGELOG.md
- [ ] Added test cases to [the relevant parts of the codebase](https://github.com/TecharoHQ/anubis/blob/main/CONTRIBUTING.md)
- [ ] Ran integration tests `npm run test:integration` (unsupported on Windows, please use WSL)
- [x] All of my commits have [verified signatures](https://anubis.techaro.lol/docs/developer/signed-commits)
