### PR TITLE
docs: fix broken link in docs to other docs

### DIFF
--- a/docs/docs/admin/policies.mdx
+++ b/docs/docs/admin/policies.mdx
@@ -91,7 +91,7 @@ Challenges can be configured with these settings:
 
 | Key          | Example  | Description                                                                                                                                                      |
 | :----------- | :------- | :--------------------------------------------------------------------------------------------------------------------------------------------------------------- |
-| `difficulty` | `4`      | The challenge difficulty (number of leading zeros) for proof-of-work. See [Why does Anubis use Proof-of-Work?](/docs/design/why-proof-of-work) for more details. |
+| `difficulty` | `4`      | The challenge difficulty (number of leading zeros) for proof-of-work. See [Why does Anubis use Proof-of-Work?](/docs/docs/design/why-proof-of-work.mdx) for more details. |
 | `algorithm`  | `"fast"` | The challenge method to use. See [the list of challenge methods](./configuration/challenges/) for more information.                                              |
 
 ### Remote IP based filtering


### PR DESCRIPTION
This is an extremly minor change which should fix a broken documentation link.

Checklist:
- N/A to all others
- [X] All of my commits have [verified signatures](https://anubis.techaro.lol/docs/developer/signed-commits)
