### PR TITLE
fix(lib): drop Partitioned cookie flag when Secure is disabled

### DIFF
--- a/cmd/anubis/main.go
+++ b/cmd/anubis/main.go
@@ -168,6 +168,9 @@ func makeReverseProxy(target string, targetSNI string, targetHost string, insecu
 		slog.Warn("TARGET_INSECURE_SKIP_VERIFY is set to true, TLS certificate validation will not be performed", "target", target)
 		transport.TLSClientConfig.InsecureSkipVerify = true
 	}
+	if *cookiePartitioned && !*cookieSecure {
+		slog.Warn("cookie-partitioned is enabled but cookie-secure is disabled; browsers reject Partitioned cookies without Secure, so the Partitioned flag will be dropped", "cookie-partitioned", *cookiePartitioned, "cookie-secure", *cookieSecure)
+	}
 	if targetSNI != "" && targetSNI != "auto" {
 		transport.TLSClientConfig.ServerName = targetSNI
 	}

--- a/lib/anubis_test.go
+++ b/lib/anubis_test.go
@@ -283,58 +283,64 @@ func TestCookieSettings(t *testing.T) {
 	const cookieDomain = "127.0.0.1"
 
 	testCases := []struct {
-		name         string
-		partitioned  bool
-		secure       bool
-		httpOnly     bool
-		sameSite     http.SameSite
-		wantSameSite http.SameSite
-		expiration   time.Duration
+		name            string
+		partitioned     bool
+		wantPartitioned bool
+		secure          bool
+		httpOnly        bool
+		sameSite        http.SameSite
+		wantSameSite    http.SameSite
+		expiration      time.Duration
 	}{
 		{
-			name:         "secure samesite none is preserved",
-			partitioned:  true,
-			secure:       true,
-			httpOnly:     false,
-			sameSite:     http.SameSiteNoneMode,
-			wantSameSite: http.SameSiteNoneMode,
-			expiration:   anubis.CookieDefaultExpirationTime,
+			name:            "secure samesite none is preserved",
+			partitioned:     true,
+			wantPartitioned: true,
+			secure:          true,
+			httpOnly:        false,
+			sameSite:        http.SameSiteNoneMode,
+			wantSameSite:    http.SameSiteNoneMode,
+			expiration:      anubis.CookieDefaultExpirationTime,
 		},
 		{
-			name:         "secure samesite none with httponly is preserved",
-			partitioned:  true,
-			secure:       true,
-			httpOnly:     true,
-			sameSite:     http.SameSiteNoneMode,
-			wantSameSite: http.SameSiteNoneMode,
-			expiration:   anubis.CookieDefaultExpirationTime,
+			name:            "secure samesite none with httponly is preserved",
+			partitioned:     true,
+			wantPartitioned: true,
+			secure:          true,
+			httpOnly:        true,
+			sameSite:        http.SameSiteNoneMode,
+			wantSameSite:    http.SameSiteNoneMode,
+			expiration:      anubis.CookieDefaultExpirationTime,
 		},
 		{
-			name:         "insecure samesite none downgrades to lax",
-			partitioned:  true,
-			secure:       false,
-			httpOnly:     false,
-			sameSite:     http.SameSiteNoneMode,
-			wantSameSite: http.SameSiteLaxMode,
-			expiration:   anubis.CookieDefaultExpirationTime,
+			name:            "insecure samesite none downgrades to lax",
+			partitioned:     true,
+			wantPartitioned: false,
+			secure:          false,
+			httpOnly:        false,
+			sameSite:        http.SameSiteNoneMode,
+			wantSameSite:    http.SameSiteLaxMode,
+			expiration:      anubis.CookieDefaultExpirationTime,
 		},
 		{
-			name:         "insecure samesite lax with httponly is preserved",
-			partitioned:  false,
-			secure:       false,
-			httpOnly:     true,
-			sameSite:     http.SameSiteLaxMode,
-			wantSameSite: http.SameSiteLaxMode,
-			expiration:   anubis.CookieDefaultExpirationTime,
+			name:            "insecure samesite lax with httponly is preserved",
+			partitioned:     false,
+			wantPartitioned: false,
+			secure:          false,
+			httpOnly:        true,
+			sameSite:        http.SameSiteLaxMode,
+			wantSameSite:    http.SameSiteLaxMode,
+			expiration:      anubis.CookieDefaultExpirationTime,
 		},
 		{
-			name:         "custom expiration is honored",
-			partitioned:  false,
-			secure:       true,
-			httpOnly:     false,
-			sameSite:     http.SameSiteLaxMode,
-			wantSameSite: http.SameSiteLaxMode,
-			expiration:   10 * time.Minute,
+			name:            "custom expiration is honored",
+			partitioned:     false,
+			wantPartitioned: false,
+			secure:          true,
+			httpOnly:        false,
+			sameSite:        http.SameSiteLaxMode,
+			wantSameSite:    http.SameSiteLaxMode,
+			expiration:      10 * time.Minute,
 		},
 	}
 
@@ -387,8 +393,8 @@ func TestCookieSettings(t *testing.T) {
 			if ckie.Domain != cookieDomain {
 				t.Errorf("cookie domain is wrong, wanted %s, got: %s", cookieDomain, ckie.Domain)
 			}
-			if ckie.Partitioned != tc.partitioned {
-				t.Errorf("wanted partitioned flag %v, got: %v", tc.partitioned, ckie.Partitioned)
+			if ckie.Partitioned != tc.wantPartitioned {
+				t.Errorf("wanted partitioned flag %v, got: %v", tc.wantPartitioned, ckie.Partitioned)
 			}
 			if ckie.HttpOnly != tc.httpOnly {
 				t.Errorf("wanted httponly flag %v, got: %v", tc.httpOnly, ckie.HttpOnly)

--- a/lib/http.go
+++ b/lib/http.go
@@ -82,6 +82,7 @@ func (s *Server) SetCookie(w http.ResponseWriter, cookieOpts CookieOpts) {
 	var name = anubis.CookieName
 	var path = "/"
 	var sameSite = s.opts.CookieSameSite
+	var partitioned = s.opts.CookiePartitioned
 
 	if cookieOpts.Name != "" {
 		name = cookieOpts.Name
@@ -103,6 +104,13 @@ func (s *Server) SetCookie(w http.ResponseWriter, cookieOpts CookieOpts) {
 		sameSite = http.SameSiteLaxMode
 	}
 
+	// Partitioned cookies must be Secure (CHIPS); browsers reject a
+	// Partitioned cookie that lacks Secure. Drop the flag rather than emit
+	// a cookie the client will silently discard.
+	if partitioned && !s.opts.CookieSecure {
+		partitioned = false
+	}
+
 	http.SetCookie(w, &http.Cookie{
 		Name:        s.cookieName(name),
 		Value:       cookieOpts.Value,
@@ -111,7 +119,7 @@ func (s *Server) SetCookie(w http.ResponseWriter, cookieOpts CookieOpts) {
 		Domain:      domain,
 		HttpOnly:    s.opts.CookieHttpOnly,
 		Secure:      s.opts.CookieSecure,
-		Partitioned: s.opts.CookiePartitioned,
+		Partitioned: partitioned,
 		Path:        path,
 	})
 }
@@ -121,6 +129,7 @@ func (s *Server) ClearCookie(w http.ResponseWriter, cookieOpts CookieOpts) {
 	var name = anubis.CookieName
 	var path = "/"
 	var sameSite = s.opts.CookieSameSite
+	var partitioned = s.opts.CookiePartitioned
 
 	if cookieOpts.Name != "" {
 		name = cookieOpts.Name
@@ -137,13 +146,20 @@ func (s *Server) ClearCookie(w http.ResponseWriter, cookieOpts CookieOpts) {
 		sameSite = http.SameSiteLaxMode
 	}
 
+	// Partitioned cookies must be Secure (CHIPS); browsers reject a
+	// Partitioned cookie that lacks Secure. Drop the flag rather than emit
+	// a cookie the client will silently discard.
+	if partitioned && !s.opts.CookieSecure {
+		partitioned = false
+	}
+
 	http.SetCookie(w, &http.Cookie{
 		Name:        s.cookieName(name),
 		Value:       "",
 		MaxAge:      -1,
 		Expires:     time.Now().Add(-1 * time.Minute),
 		SameSite:    sameSite,
-		Partitioned: s.opts.CookiePartitioned,
+		Partitioned: partitioned,
 		Domain:      domain,
 		HttpOnly:    s.opts.CookieHttpOnly,
 		Secure:      s.opts.CookieSecure,

--- a/lib/http_test.go
+++ b/lib/http_test.go
@@ -136,6 +136,53 @@ func TestClearCookieWithDynamicDomain(t *testing.T) {
 	}
 }
 
+func TestSetCookiePartitionedRequiresSecure(t *testing.T) {
+	// Per CHIPS, a Partitioned cookie must also be Secure; browsers reject a
+	// Partitioned cookie that lacks Secure and behave as if no cookie was set.
+	// Both SetCookie and ClearCookie must drop the Partitioned flag when
+	// CookieSecure is false, and keep it when CookieSecure is true.
+	emitters := []struct {
+		name string
+		call func(srv *Server, rw *httptest.ResponseRecorder)
+	}{
+		{name: "SetCookie", call: func(srv *Server, rw *httptest.ResponseRecorder) {
+			srv.SetCookie(rw, CookieOpts{Value: "test", Host: "localhost"})
+		}},
+		{name: "ClearCookie", call: func(srv *Server, rw *httptest.ResponseRecorder) {
+			srv.ClearCookie(rw, CookieOpts{Host: "localhost"})
+		}},
+	}
+
+	for _, tt := range []struct {
+		name            string
+		secure          bool
+		wantPartitioned bool
+	}{
+		{name: "dropped without secure", secure: false, wantPartitioned: false},
+		{name: "kept with secure", secure: true, wantPartitioned: true},
+	} {
+		t.Run(tt.name, func(t *testing.T) {
+			for _, emit := range emitters {
+				t.Run(emit.name, func(t *testing.T) {
+					srv := spawnAnubis(t, Options{CookiePartitioned: true, CookieSecure: tt.secure})
+					rw := httptest.NewRecorder()
+
+					emit.call(srv, rw)
+
+					cookies := rw.Result().Cookies()
+					if len(cookies) != 1 {
+						t.Fatalf("wanted 1 cookie, got %d cookies", len(cookies))
+					}
+
+					if got := cookies[0].Partitioned; got != tt.wantPartitioned {
+						t.Errorf("CookieSecure=%v: wanted Partitioned=%v, got Partitioned=%v", tt.secure, tt.wantPartitioned, got)
+					}
+				})
+			}
+		})
+	}
+}
+
 func TestRenderIndexRedirect(t *testing.T) {
 	s := &Server{
 		opts: Options{


### PR DESCRIPTION
Fixes #1680

## Problem
`Server.SetCookie` and `Server.ClearCookie` set `Partitioned: s.opts.CookiePartitioned` unconditionally. The analogous `SameSite=None`-without-`Secure` case is already guarded (it downgrades to `Lax`), but `Partitioned` had no equivalent guard.

Per CHIPS, browsers reject a `Partitioned` cookie that lacks `Secure`. With `COOKIE_PARTITIONED=true` -- now the default since #1797 -- and `COOKIE_SECURE=false`, every auth-challenge and clear response emits `Set-Cookie: ...; Partitioned` with no `Secure`, so the browser silently discards it and Anubis shows "Your browser is configured to disable cookies", making the site unusable.

Reproduction (from the issue):

```
docker run --rm -p 8923:8923 \
  -e BIND=:8923 -e TARGET=http://host.docker.internal:8081 \
  -e COOKIE_PARTITIONED=true -e COOKIE_SECURE=false \
  -e USE_REMOTE_ADDRESS=true ghcr.io/techarohq/anubis:latest
```

## Fix
Mirror the existing `SameSite=None` guard in both `SetCookie` and `ClearCookie`: drop the `Partitioned` flag when `!CookieSecure`, so the emitted cookie is one the browser will actually accept. Also logs a startup warning when `cookie-partitioned` is enabled while `cookie-secure` is disabled, so operators see the misconfiguration (as suggested in the issue).

## Tests
- Added `TestSetCookiePartitionedRequiresSecure` covering both `SetCookie` and `ClearCookie`: asserts `Partitioned` is absent when `CookieSecure=false`, and present (regression) when both are true.
- Red/green verified: the test fails against the old unconditional behavior and passes with the guard. `go build ./...`, `go vet ./lib/ ./cmd/anubis/`, and `gofmt` are clean.

Thanks to @tdgroot for reporting #1680 and outlining the fix direction.

---
This change was prepared with AI assistance and reviewed by me before submission.