### PR TITLE
fix(web/js): properly spawn workers with strict CSP settings

### DIFF
--- a/.vscode/project-words.txt
+++ b/.vscode/project-words.txt
@@ -416,6 +416,7 @@ reimagining
 remoteip
 reputational
 resourced
+respawning
 Rhul
 rififi
 risc

--- a/docs/docs/CHANGELOG.md
+++ b/docs/docs/CHANGELOG.md
@@ -18,6 +18,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Improved Norwegian Nynorsk localization.
 - Stop clearing the authorization cookie when a challenged request did not send one. A subresource request that starts before the challenge is passed but finishes after it no longer deletes the cookie that `pass-challenge` just issued ([#1314](https://github.com/TecharoHQ/anubis/issues/1314)).
 - Fix proof of work worker spawning fallback logic to properly detect Content-Security-Policy failures and fall back to the older logic that fans out to one request per hardware core ([#1864](https://github.com/TecharoHQ/anubis/issues/1864)).
+- [Content-Security-Policy advice](./admin/configuration/content-security-policy.mdx) has been added to the documentation.
 
 ## v1.27.0: Moenbryda Wilfsunnwyn
 

--- a/docs/docs/CHANGELOG.md
+++ b/docs/docs/CHANGELOG.md
@@ -17,6 +17,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Add weighing rule for [Cloudflare Kitesurf](https://blog.cloudflare.com/kitesurf/). Kitesurf doesn't currently support Cookies, but it might in the future.
 - Improved Norwegian Nynorsk localization.
 - Stop clearing the authorization cookie when a challenged request did not send one. A subresource request that starts before the challenge is passed but finishes after it no longer deletes the cookie that `pass-challenge` just issued ([#1314](https://github.com/TecharoHQ/anubis/issues/1314)).
+- Fix proof of work worker spawning fallback logic to properly detect Content-Security-Policy failures and fall back to the older logic that fans out to one request per hardware core ([#1864](https://github.com/TecharoHQ/anubis/issues/1864)).
 
 ## v1.27.0: Moenbryda Wilfsunnwyn
 

--- a/docs/docs/admin/configuration/content-security-policy.mdx
+++ b/docs/docs/admin/configuration/content-security-policy.mdx
@@ -1,0 +1,42 @@
+# Content-Security-Policy advice
+
+Many web server configuration guides recommend setting a strict [Content-Security-Policy (CSP)](https://developer.mozilla.org/en-US/docs/Web/HTTP/Guides/CSP) on your web applications in order to avoid [Cross-Site-Scripting (XSS)](https://en.wikipedia.org/wiki/Cross-site_scripting) from being able to affect your services. The way Anubis works can conflict with some common CSP settings that many guides and web applications enforce out of the gate.
+
+:::warning
+
+Browsers cache the contents of `Content-Security-Policy` headers for a very long time. Please be sure to test any of these changes on staging domains before deploying changes to production.
+
+:::
+
+The most strict yet correct CSP for Anubis looks like this (reformatted for readability):
+
+```text
+default-src 'none';
+script-src  'self' 'unsafe-inline';
+style-src   'self' 'unsafe-inline';
+img-src     'self';
+font-src    'self' data:;
+connect-src 'self';
+worker-src  'self' blob:;
+base-uri    'none';
+form-action 'self';
+```
+
+This is an overly strict CSP and you **will** need to edit this as it **will** interfere with the normal operation of many web applications, especially ones that include resources from remote destinations to function (EG: the image CDN for a social media network).
+
+Breaking it down:
+
+| Setting                      | Justification                                                                                                                                                                                                                                                                                                                                                                                                   |
+| :--------------------------- | :-------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| `default-src 'none'`         | Blocks every kind of subresource load unless specified below. This denies by default. This setting alone is likely to break web applications.                                                                                                                                                                                                                                                                   |
+| `script-src 'self'`          | Anubis checks that load JavaScript from the server via the `<script>` tag needs to be allowed to load JavaScript from the server.                                                                                                                                                                                                                                                                               |
+| `script-src 'unsafe-inline'` | Anubis has fallback behaviour to make sure that JavaScript loaded from `<script>` tags actually gets loaded. Browsers don't expose errors for servers returning non-JavaScript responses when trying to load JavaScript programs, so Anubis embeds a small inline JavaScript program that makes sure the JavaScript actually gets loaded from the server and retries with exponential backoff in case it fails. |
+| `style-src 'unsafe-inline'`  | Anubis has some critical parts of its CSS embedded directly into the challenge page. This setting also triggers the use of the HTML `style="..."` attribute and JavaScript `DOMElement.style` properties. This is required for Anubis to function as it triggers success/failure message visibility and styling.                                                                                                |
+| `style-src 'self'`           | Anubis loads CSS from the server. Not loading CSS from the server may make Anubis think that a client is a bot.                                                                                                                                                                                                                                                                                                 |
+| `img-src 'self'`             | Anubis loads its image resources from the server. Not loading these images from the server may make Anubis think the client is a bot.                                                                                                                                                                                                                                                                           |
+| `font-src data:`             | Anubis embeds fonts into its stylesheet so that errant scrapers think the Anubis challenge page is a legitimate webpage.                                                                                                                                                                                                                                                                                        |
+| `connect-src 'self'`         | Anubis pre-fetches worker source and translation locales from the server.                                                                                                                                                                                                                                                                                                                                       |
+| `worker-src blob:`           | Anubis pre-fetches worker source to avoid fanning out a request for every hardware thread to read that worker source. If this is not set, Anubis falls back to the expensive fanning out requests for every hardware thread.                                                                                                                                                                                    |
+| `worker-src 'self'`          | In fallback scenarios, Anubis loads worker source by fanning out requests per hardware thread to load the same JavaScript source. Disabling this makes the JavaScript code not load, which causes Anubis' frontend code to throw an error.                                                                                                                                                                      |
+| `base-uri 'none'`            | Restricts the URLs allowed in [HTML `<base>` elements](https://developer.mozilla.org/en-US/docs/Web/HTML/Reference/Elements/base). Anubis does not use this HTML element.                                                                                                                                                                                                                                       |
+| `form-action 'self'`         | Controls where `<form>` actions may go. Anubis does not use HTML forms, but your web application might.                                                                                                                                                                                                                                                                                                         |

--- a/internal/test/csp_test.go
+++ b/internal/test/csp_test.go
@@ -1,0 +1,167 @@
+package test
+
+import (
+	"fmt"
+	"net"
+	"net/http"
+	"net/http/httptest"
+	"os"
+	"strconv"
+	"testing"
+	"time"
+
+	"github.com/TecharoHQ/anubis"
+	libanubis "github.com/TecharoHQ/anubis/lib"
+	"github.com/mxschmitt/playwright-go"
+)
+
+// blobBlockingCSP is the Content-Security-Policy (CSP) reported in
+// TecharoHQ/anubis#1864. This CSP doesn't set worker-src, so worker-src
+// falls back through script-src to `default-src 'self'`, which does not
+// cover blob: URIs.
+//
+// In order to reduce server request pressure, Anubis pre-fetches browser
+// worker JS from the server and packs it into a blob: URI. This policy
+// makes browsers reject that behaviour as an error event, leading the
+// workers to all die off and then users to be SOL.
+//
+// This policy also enforces Anubis to fall back to the old behaviour
+// where each worker fetches its own copy of the worker script in one
+// request per thread. This kinda sucks, but such is life in late-stage
+// capitalism.
+const blobBlockingCSP = "default-src 'self' 'unsafe-eval' 'unsafe-inline'; img-src * data:;"
+
+func TestPlaywrightBlobWorkerBlockedByCSP(t *testing.T) {
+	if os.Getenv("DONT_USE_NETWORK") != "" {
+		t.Skip("test requires network egress")
+		return
+	}
+
+	if os.Getenv("SKIP_INTEGRATION") != "" {
+		t.Skip("SKIP_INTEGRATION was set")
+		return
+	}
+
+	startPlaywright(t)
+
+	pw := setupPlaywright(t)
+	anubisURL := spawnAnubisWithCSP(t, "", blobBlockingCSP)
+
+	for _, typ := range []playwright.BrowserType{pw.Chromium, pw.Firefox, pw.WebKit} {
+		t.Run(typ.Name(), func(t *testing.T) {
+			browser, err := typ.Connect(buildBrowserConnect(typ.Name()))
+			if err != nil {
+				t.Fatalf("could not connect to remote browser: %v", err)
+			}
+			defer browser.Close()
+
+			ctx, err := browser.NewContext(playwright.BrowserNewContextOptions{
+				AcceptDownloads: playwright.Bool(false),
+				ExtraHttpHeaders: map[string]string{
+					"X-Real-Ip": placeholderIP,
+				},
+				UserAgent: playwright.String("Mozilla/5.0 (X11; Linux x86_64; rv:136.0) Gecko/20100101 Firefox/136.0"),
+			})
+			if err != nil {
+				t.Fatalf("could not create context: %v", err)
+			}
+			defer ctx.Close()
+
+			page, err := ctx.NewPage()
+			if err != nil {
+				t.Fatalf("could not create page: %v", err)
+			}
+			defer page.Close()
+
+			page.OnConsole(func(msg playwright.ConsoleMessage) {
+				t.Logf("console: %s", msg.Text())
+			})
+
+			if _, err := page.Goto(anubisURL, playwright.PageGotoOptions{
+				Timeout: playwright.Float(float64(playwrightMaxTime.Milliseconds())),
+			}); err != nil {
+				t.Fatalf("could not navigate to test server: %v", err)
+			}
+
+			if err := page.Locator("#anubis-test").WaitFor(playwright.LocatorWaitForOptions{
+				Timeout: playwright.Float(float64(challengeSolveTimeout.Milliseconds())),
+			}); err != nil {
+				t.Fatal(pwFail(t, page, "challenge did not complete under a CSP that forbids blob: workers: %v", err))
+			}
+		})
+	}
+}
+
+// challengeSolveTimeout is the maximum amount of time browsers get to solve
+// test challenges. By default this _should_ be good enough on the hardware
+// that CI runs on. If this ends up being a bad assumption, revise this
+// constant and document the tale of woe here.
+const challengeSolveTimeout = 30 * time.Second
+
+// spawnAnubisWithCSP starts Anubis with an additional inline middleware
+// that stamps every request with the given Content-Security-Policy, which
+// imitates the behaviour in TecharoHQ/anubis#1864 that caused workers to
+// be unable to spawn.
+//
+// If you set no csp value, no Content-Security-Policy is injected.
+func spawnAnubisWithCSP(t *testing.T, basePrefix, csp string) string {
+	t.Helper()
+
+	h := http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Add("Content-Type", "text/html")
+		fmt.Fprintf(w, "<html><body><span id=anubis-test>%d</span></body></html>", time.Now().Unix())
+	})
+
+	policy, err := libanubis.LoadPoliciesOrDefault(t.Context(), "", anubis.DefaultDifficulty, "info", false)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	// Bind loopback explicitly: binding every interface makes ts.URL the
+	// unspecified address (http://[::]:port), which Firefox refuses to navigate
+	// to with NS_ERROR_CONNECTION_REFUSED.
+	listener, err := net.Listen("tcp", "127.0.0.1:0")
+	if err != nil {
+		t.Fatalf("can't listen on random port: %v", err)
+	}
+
+	// XXX(Xe): I'd love to use httptest.NewServer for this, but we need to know
+	// the address of the target ahead of time.
+	addr := listener.Addr().(*net.TCPAddr)
+	host := "localhost"
+	port := strconv.Itoa(addr.Port)
+
+	s, err := libanubis.New(libanubis.Options{
+		Next:             h,
+		Policy:           policy,
+		ServeRobotsTXT:   true,
+		Target:           "http://" + host + ":" + port,
+		BasePrefix:       basePrefix,
+		CookieExpiration: anubis.CookieDefaultExpirationTime,
+	})
+	if err != nil {
+		t.Fatalf("can't construct libanubis.Server: %v", err)
+	}
+
+	var handler http.Handler = s
+	if csp != "" {
+		inner := handler
+		handler = http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+			w.Header().Set("Content-Security-Policy", csp)
+			inner.ServeHTTP(w, r)
+		})
+	}
+
+	ts := &httptest.Server{
+		Listener: listener,
+		Config:   &http.Server{Handler: handler},
+	}
+	ts.Start()
+	t.Log(ts.URL)
+
+	t.Cleanup(func() {
+		ts.Close()
+	})
+
+	return ts.URL
+}

--- a/internal/test/playwright_test.go
+++ b/internal/test/playwright_test.go
@@ -18,20 +18,16 @@ package test
 import (
 	"flag"
 	"fmt"
-	"net"
 	"net/http"
-	"net/http/httptest"
 	"net/url"
 	"os"
 	"os/exec"
-	"strconv"
 	"strings"
 	"syscall"
 	"testing"
 	"time"
 
 	"github.com/TecharoHQ/anubis"
-	libanubis "github.com/TecharoHQ/anubis/lib"
 	"github.com/mxschmitt/playwright-go"
 )
 
@@ -599,51 +595,5 @@ func spawnAnubis(t *testing.T) string {
 }
 
 func spawnAnubisWithOptions(t *testing.T, basePrefix string) string {
-	t.Helper()
-
-	h := http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
-		w.Header().Add("Content-Type", "text/html")
-		fmt.Fprintf(w, "<html><body><span id=anubis-test>%d</span></body></html>", time.Now().Unix())
-	})
-
-	policy, err := libanubis.LoadPoliciesOrDefault(t.Context(), "", anubis.DefaultDifficulty, "info", false)
-	if err != nil {
-		t.Fatal(err)
-	}
-
-	// Bind loopback explicitly: binding every interface makes ts.URL the
-	// unspecified address (http://[::]:port), which Firefox refuses to navigate
-	// to with NS_ERROR_CONNECTION_REFUSED.
-	listener, err := net.Listen("tcp", "127.0.0.1:0")
-	if err != nil {
-		t.Fatalf("can't listen on random port: %v", err)
-	}
-
-	addr := listener.Addr().(*net.TCPAddr)
-	host := "localhost"
-	port := strconv.Itoa(addr.Port)
-
-	s, err := libanubis.New(libanubis.Options{
-		Next:           h,
-		Policy:         policy,
-		ServeRobotsTXT: true,
-		Target:         "http://" + host + ":" + port,
-		BasePrefix:     basePrefix,
-	})
-	if err != nil {
-		t.Fatalf("can't construct libanubis.Server: %v", err)
-	}
-
-	ts := &httptest.Server{
-		Listener: listener,
-		Config:   &http.Server{Handler: s},
-	}
-	ts.Start()
-	t.Log(ts.URL)
-
-	t.Cleanup(func() {
-		ts.Close()
-	})
-
-	return ts.URL
+	return spawnAnubisWithCSP(t, basePrefix, "")
 }

--- a/web/js/algorithms/fast.ts
+++ b/web/js/algorithms/fast.ts
@@ -59,9 +59,12 @@ function runWorkers(
   threads: number,
 ): Promise<ProcessResult> {
   return new Promise((resolve, reject) => {
-    const workers: Worker[] = [];
+    let workers: Worker[] = [];
     let settled = false;
     let deadWorkers = 0;
+    // XXX(Xe): sentinel for workers, if this is not set then a CSP refused
+    // to load scripts normally.
+    let anyOutput = false;
 
     const onAbort = () => {
       console.log("PoW aborted");
@@ -69,12 +72,21 @@ function runWorkers(
       reject(new DOMException("Aborted", "AbortError"));
     };
 
+    const stopWorkers = () => {
+      workers.forEach((w) => {
+        w.onmessage = null;
+        w.onerror = null;
+        w.terminate();
+      });
+      workers = [];
+    };
+
     const cleanup = () => {
       if (settled) {
         return;
       }
       settled = true;
-      workers.forEach((w) => w.terminate());
+      stopWorkers();
       if (signal != null) {
         signal.removeEventListener("abort", onAbort);
       }
@@ -87,74 +99,105 @@ function runWorkers(
       signal.addEventListener("abort", onAbort, { once: true });
     }
 
-    for (let i = 0; i < threads; i++) {
-      let worker: Worker;
-      try {
-        worker = spawner.spawn();
-      } catch (err) {
-        // If we can't spawn workers, we're in a weird place. Bail by cleaning
-        // up and throwing an error up the stack so that the user can report
-        // Terminate the workers we already started. Letting them leak leaves
-        // spinning infinite loops behind that burn a core until navigation.
-        cleanup();
-        reject(
-          new Error(
-            `anubis: could not start proof of work worker: ${err} (is your browser out of date?)`,
-          ),
-        );
-        return;
-      }
+    const startWorkers = () => {
+      deadWorkers = 0;
 
-      // Track the worker before doing anything else with it so cleanup() can
-      // always reach it.
-      workers.push(worker);
-
-      worker.onmessage = (event) => {
-        if (typeof event.data === "number") {
-          progressCallback?.(event.data);
-        } else {
+      for (let i = 0; i < threads; i++) {
+        let worker: Worker;
+        try {
+          worker = spawner.spawn();
+        } catch (err) {
+          // If we can't spawn workers, we're in a weird place. Throw an error
+          // up the stack and kill the workers so they don't burn CPU and try
+          // to send a message that won't be read.
           cleanup();
-          resolve(event.data);
-        }
-      };
-
-      worker.onerror = (event) => {
-        deadWorkers++;
-        console.warn(
-          `anubis: proof of work worker died (${deadWorkers}/${threads})`,
-          event,
-        );
-
-        // Losing a worker isn't fatal, it does mean that the nonce lane that
-        // the worker covers isn't being covered anymore, but the other workers
-        // will cover the other nonce lanes. This means that losing one lane
-        // costs throughput but not correctness. Solutions generally should
-        // be dense enough that survivors should still find one.
-        //
-        // However if all workers die, then the entire process is dead and we
-        // need to surface this up to the user.
-        if (deadWorkers < threads) {
+          reject(
+            new Error(
+              `anubis: could not start proof of work worker: ${err} (is your browser out of date?)`,
+            ),
+          );
           return;
         }
 
-        cleanup();
-        // If the worker fails to load, some browsers return non-error Error
-        // values that we can't introspect properly. When we hit this kind of
-        // horrible state, throw an actual error so that the challenge page
-        // has a better error message than "undefined".
-        reject(
-          new Error(
-            "anubis: all proof of work workers failed at runtime (file a bug?)",
-          ),
-        );
-      };
+        workers.push(worker);
 
-      worker.postMessage({
-        data,
-        difficulty,
-        nonce: i,
-        threads,
-      });
-    }
+        worker.onmessage = (event) => {
+          // Feed the watchdog.
+          anyOutput = true;
+
+          if (typeof event.data === "number") {
+            progressCallback?.(event.data);
+          } else {
+            cleanup();
+            resolve(event.data);
+          }
+        };
+
+        worker.onerror = (event) => {
+          // XXX(Xe): Workers should generally be inerrant. If any of them has
+          // died before producing any output then they have never ran because
+          // the browser explicitly rejected the worker script due to an overly
+          // strict Content-Security-Policy.
+          //
+          // Annoyingly, this isn't something that's easy to catch and validate
+          // so we just check to make sure that we've seen at least _any_ output
+          // from the worker and if we haven't then try to run the fallback
+          // logic that makes N requests for N = getHardwareConcurrency().
+          //
+          // This can cause some issues with particularly overloaded servers
+          // that can't route to Anubis due to biblical amounts of load, but
+          // what can you do? At that point you kinda have to pick your battles
+          // between reliability and consistency. Consistency is probably the
+          // better tradeoff.
+          if (!anyOutput && spawner.demote()) {
+            console.warn(
+              "anubis: proof of work workers died without running, respawning them",
+            );
+            stopWorkers();
+            startWorkers();
+            return;
+          }
+
+          deadWorkers++;
+          console.warn(
+            `anubis: proof of work worker died (${deadWorkers}/${threads})`,
+            event,
+          );
+
+          // XXX(Xe): Make sure there's at least one worker left alive.
+          //
+          // One way to think about how the parallelism works here is that the
+          // nonce space of challenge solutions is divided into one "lane" per
+          // worker. In general solutions should be "dense" enough that losing
+          // a few workers should be "fine enough".
+          //
+          // If all workers are dead, there is no way to search the entire nonce
+          // space and thus the solution attempt has failed.
+          if (deadWorkers < threads) {
+            return;
+          }
+
+          cleanup();
+          // XXX(Xe): If the worker fails to load, some browsers return non-error
+          // Error values that we can't introspect properly. When we hit this kind 
+          // of horrible state, throw an actual error so that the challenge page
+          // has a better error message than "undefined".
+          reject(
+            new Error(
+              "anubis: all proof of work workers failed at runtime (file a bug?)",
+            ),
+          );
+        };
+
+        worker.postMessage({
+          data,
+          difficulty,
+          nonce: i,
+          threads,
+        });
+      }
+    };
+
+    startWorkers();
   });
 }

--- a/web/js/lib/worker.ts
+++ b/web/js/lib/worker.ts
@@ -31,6 +31,9 @@ export interface WorkerArgs {
 export interface WorkerSpawner {
   // spawn a single worker based on the template
   spawn: () => Worker;
+  // demote to fallback/less efficient logic instead of using more efficient
+  // logic.
+  demote: () => boolean;
   // destroy this instance, manual cleanup logic so you don't leak Blob
   // instances, etc.
   dispose: () => void;
@@ -39,7 +42,8 @@ export interface WorkerSpawner {
 export const directSpawner = (webWorkerURL: string): WorkerSpawner => {
   return {
     spawn: () => new Worker(webWorkerURL),
-    dispose: () => {},
+    demote: () => false,
+    dispose: () => { },
   };
 };
 
@@ -62,9 +66,10 @@ export const directSpawner = (webWorkerURL: string): WorkerSpawner => {
  * the wrong asset". To work around this we have to `fetch()` the contents
  * of the worker code and spawn it with a Blob.
  *
- * If anything goes wrong or the server's Content-Security-Policy forbids
- * putting worker sources in Blobs, we fall back to the old behaviour with
- * the caveat that doing this is kinda hacky and terrible, but such is life.
+ * If anything goes wrong or the server's Content-Security-Policy (CSP) 
+ * forbids putting worker sources in Blobs, we fall back to the old behaviour
+ * with the caveat that doing this is kinda hacky and terrible, but such is
+ * life.
  */
 export const createWorkerSpawner = async (
   webWorkerURL: string,
@@ -95,18 +100,30 @@ export const createWorkerSpawner = async (
   let useBlob = true;
 
   return {
-    spawn: () => {
+    spawn: (): Worker => {
       if (useBlob) {
         try {
           return new Worker(blobURL);
         } catch (err) {
-          // Most likely a CSP that forbids blob: workers.
+          // XXX(Xe): Chrome, Firefox, and WebKit won't trigger this, but it's best
+          // to be defensive here.
           console.warn("anubis: blob worker rejected, using direct URL", err);
           useBlob = false;
         }
       }
       return new Worker(webWorkerURL);
     },
-    dispose: () => URL.revokeObjectURL(blobURL),
+    demote: (): boolean => {
+      if (!useBlob) {
+        return false;
+      }
+
+      console.warn(
+        "anubis: blob workers are not running, falling back to loading workers from their own URL (does this site's Content-Security-Policy allow blob: in worker-src?)",
+      );
+      useBlob = false;
+      return true;
+    },
+    dispose: (): void => URL.revokeObjectURL(blobURL),
   };
 };


### PR DESCRIPTION
Content-Security-Policies[1] are a rabbit hole. The core reason that they exist is because browsers are programs that are installed on and run on arbitrary user computers. In order to reduce the risk of Cross-Site-Scripting (XSS) attacks, Content-Security-Policies let administrators explicitly disable or limit the featureset of a browser for a given page.

Anubis uses a method of spawning Workers that many common Content-Security-Policies disallow, specifically one where the worker source is downloaded from the server, packed into a blob: URI[2], and then that in-memory JavaScript source is used to spawn workers. This works great and prevents the problem where browsers would otherwise fan out HTTP requests to the load balancer for every core in getHardwareConcurrency. In normal cases, this is fine, HTTP daemons can handle the trivial load without issue. In exceptional cases where Apache is out of workers or the epoll() subsystem of nginx is under tremendous load from scraping attacks, this can cause issues to spill over into user-facing problems where the workers for Anubis' challenge methods can't load.

Previously I assumed that a CSP violation for Worker source would result in an error being thrown when creating a Worker instance as I had read in documentation that was clearly wrong and/or AI slop (not sure which, I made the mistake of not copying the URL I read it from). It turns out that browsers actually return a Worker instance successfully, fork that process into the background, notice the CSP violation, and then raises an asynchronous error that way.

In order to work around this, make sure that the JavaScript keeps track of the workers _ever_ returning any progress updates. If they have not and all workers have failed, the Content-Security-Policy has rejected our attempts to load the worker source via the efficent method and we have to fall back to the fan-out inefficient method.

This only really works because the Anubis workers are generally assumed to be inerrant unless something has gone so catastrophically wrong that there is a logical assertion failure that needs to result in changed life decisions. In general, the frontend can tolerate losing workers at the cost of the "nonce lane" that worker would cover being skipped over. Solutions should generally be "dense" enough that this isn't a huge issue, but can make solutions that were in the missing nonce lane be skipped.

One of the side effects of this change is that the WorkerSpawner interface had to change to have its caller signal that workers need to be spawned using a less efficient method ("demoting" it).

Aren't computers great?

[1]: https://developer.mozilla.org/en-US/docs/Web/HTTP/Guides/CSP
[2]: https://developer.mozilla.org/en-US/docs/Web/URI/Reference/Schemes/blob

Fixes: #1864

<!--
delete me and describe your change here, give enough context for a maintainer to understand what and why

See https://github.com/TecharoHQ/anubis/blob/main/CONTRIBUTING.md for more information
-->

Checklist:

- [x] Added a description of the changes to the `[Unreleased]` section of docs/docs/CHANGELOG.md
- [x] Added test cases to [the relevant parts of the codebase](https://github.com/TecharoHQ/anubis/blob/main/CONTRIBUTING.md)
- [x] Ran integration tests `npm run test:integration` (unsupported on Windows, please use WSL)
- [x] All of my commits have [verified signatures](https://anubis.techaro.lol/docs/developer/signed-commits)
