### PR TITLE
feat(anubis): log when challenges are accepted

### DIFF
--- a/lib/anubis.go
+++ b/lib/anubis.go
@@ -539,6 +539,8 @@ func (s *Server) PassChallenge(w http.ResponseWriter, r *http.Request) {
 		}
 	}
 
+	lg.Info("challenge accepted", "challenge", chall.ID)
+
 	// generate JWT cookie
 	var tokenString string
 


### PR DESCRIPTION
Adds a structured log line in Server.PassChallenge when a submitted challenge validates successfully, completing the challenge lifecycle's existing observability (logs for failed and invalid challenges are already included).

*Why*
The failure paths are already surfaced (lg.Error on ErrFailed, invalid format, missing field), but a successful pass is silent unless the log level is Debug. This gives administrators a single log line to confirm which challenge a cookie was issued from, which helps when debugging clients that pass then get blocked, or tracing whether a challenge was redeemed at all.

Checklist:

- [] Added a description of the changes to the `[Unreleased]` section of docs/docs/CHANGELOG.md
- [x] Added test cases to [the relevant parts of the codebase](https://github.com/TecharoHQ/anubis/blob/main/CONTRIBUTING.md)
- [x] Ran integration tests `npm run test:integration` (unsupported on Windows, please use WSL)
- [x] All of my commits have [verified signatures](https://anubis.techaro.lol/docs/developer/signed-commits)
