### PR TITLE
fix(internal): overwrite X-Real-Ip from recomputed X-Forwarded-For

### DIFF
--- a/docs/docs/CHANGELOG.md
+++ b/docs/docs/CHANGELOG.md
@@ -20,6 +20,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Fix proof of work worker spawning fallback logic to properly detect Content-Security-Policy failures and fall back to the older logic that fans out to one request per hardware core ([#1864](https://github.com/TecharoHQ/anubis/issues/1864)).
 - [Content-Security-Policy advice](./admin/configuration/content-security-policy.mdx) has been added to the documentation.
 - Detect and block trivial attempts at [domain fronting](https://en.wikipedia.org/wiki/Domain_fronting) as bots have been starting to use that to try and turn web applications or HTTP servers into open proxies.
+- Overwrite `X-Real-Ip` from the recomputed `X-Forwarded-For` instead of only filling it when unset, so a client-forged `X-Real-Ip` cannot survive to policy checks or the upstream target. If no IP can be derived, the header is removed.
 
 ## v1.27.0: Moenbryda Wilfsunnwyn
 

--- a/docs/docs/admin/caveats-xff.mdx
+++ b/docs/docs/admin/caveats-xff.mdx
@@ -22,6 +22,6 @@ As a workaround, you should configure your web server to parse an alternative so
 
 If you do not control the web server upstream of Anubis, the `custom-real-ip-header` command line flag accepts a header value that Anubis will read the real client IP address from. Anubis will set the `X-Real-IP` header to the IP address found in the custom header.
 
-The `X-Real-IP` header will be automatically inferred from `X-Forwarded-For` if not set, setting it explicitly is not necessary as long as `X-Forwarded-For` contains only the real client IP. However setting it explicitly can eliminate spoofed values if your web server doesn't set this.
+The `X-Real-IP` header is always inferred from the flattened `X-Forwarded-For`, overwriting any client-supplied value: a request that arrives with a forged `X-Real-IP` cannot keep it through to policy checks or the upstream target. If the flattened `X-Forwarded-For` yields no usable IP, the `X-Real-IP` header is removed. If your web server knows the client IP better than the flattened `X-Forwarded-For` does, have it expose that IP in a dedicated header (such as `CF-Connecting-IP`) and pass that header's name to the `custom-real-ip-header` flag, or enable `use-remote-address`; both overwrite `X-Real-IP` with the operator-controlled source.
 
 See [Cloudflare](environments/cloudflare.mdx) for an example configuration.

--- a/internal/headers.go
+++ b/internal/headers.go
@@ -93,17 +93,23 @@ func RemoteXRealIP(useRemoteAddress bool, bindNetwork string, next http.Handler)
 	})
 }
 
-// XForwardedForToXRealIP sets the X-Real-Ip header based on the contents
-// of the X-Forwarded-For header.
+// XForwardedForToXRealIP overwrites the X-Real-Ip header from the (already
+// recomputed) X-Forwarded-For header, so client-forged values cannot reach
+// policy evaluation or the upstream target.
 func XForwardedForToXRealIP(next http.Handler) http.Handler {
 	return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
-		if xffHeader := r.Header.Get("X-Forwarded-For"); r.Header.Get("X-Real-Ip") == "" && xffHeader != "" {
-			ip := xff.Parse(xffHeader)
-			slog.DebugContext(r.Context(), "setting X-Real-Ip from X-Forwarded-For", "to", ip, "x-forwarded-for", xffHeader)
-			r.Header.Set("X-Real-Ip", ip)
-			if addr, err := netip.ParseAddr(ip); err == nil {
-				r = r.WithContext(context.WithValue(r.Context(), realIPKey{}, addr))
-			}
+		ip := xff.Parse(r.Header.Get("X-Forwarded-For"))
+		if ip == "" {
+			slog.DebugContext(r.Context(), "removing X-Real-Ip, no usable X-Forwarded-For", "x-forwarded-for", r.Header.Get("X-Forwarded-For"))
+			r.Header.Del("X-Real-Ip")
+			next.ServeHTTP(w, r)
+			return
+		}
+
+		slog.DebugContext(r.Context(), "setting X-Real-Ip from X-Forwarded-For", "to", ip, "x-forwarded-for", r.Header.Get("X-Forwarded-For"))
+		r.Header.Set("X-Real-Ip", ip)
+		if addr, err := netip.ParseAddr(ip); err == nil {
+			r = r.WithContext(context.WithValue(r.Context(), realIPKey{}, addr))
 		}
 
 		next.ServeHTTP(w, r)

--- a/internal/xff_test.go
+++ b/internal/xff_test.go
@@ -186,3 +186,68 @@ func TestComputeXFFHeader(t *testing.T) {
 		})
 	}
 }
+
+func TestXForwardedForToXRealIPOverwritesForgedHeader(t *testing.T) {
+	var realIP = "sentinel"
+
+	h := http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		realIP = r.Header.Get("X-Real-Ip")
+		if addr, ok := RealIP(r); !ok || addr.String() != "203.0.113.5" {
+			t.Errorf("wanted RealIP context to be 203.0.113.5, got: %v (%v)", addr, ok)
+		}
+		w.WriteHeader(http.StatusOK)
+	})
+
+	r := httptest.NewRequest(http.MethodGet, "/", nil)
+	r.Header.Set("X-Real-Ip", "5.6.7.8")
+	r.Header.Set("X-Forwarded-For", "203.0.113.5")
+
+	w := httptest.NewRecorder()
+
+	XForwardedForToXRealIP(h).ServeHTTP(w, r)
+
+	if realIP != "203.0.113.5" {
+		t.Errorf("wanted X-Real-Ip to be overwritten with 203.0.113.5, got: %q", realIP)
+	}
+}
+
+func TestXForwardedForToXRealIPDeletesWhenXFFUnusable(t *testing.T) {
+	var realIP = "sentinel"
+
+	h := http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		realIP = r.Header.Get("X-Real-Ip")
+		w.WriteHeader(http.StatusOK)
+	})
+
+	r := httptest.NewRequest(http.MethodGet, "/", nil)
+	r.Header.Set("X-Real-Ip", "5.6.7.8")
+	r.Header.Set("X-Forwarded-For", "10.0.0.5")
+
+	w := httptest.NewRecorder()
+
+	XForwardedForToXRealIP(h).ServeHTTP(w, r)
+
+	if realIP != "" {
+		t.Errorf("wanted X-Real-Ip to be deleted when X-Forwarded-For is unusable, got: %q", realIP)
+	}
+}
+
+func TestXForwardedForToXRealIPFillsWhenUnset(t *testing.T) {
+	var realIP = "sentinel"
+
+	h := http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		realIP = r.Header.Get("X-Real-Ip")
+		w.WriteHeader(http.StatusOK)
+	})
+
+	r := httptest.NewRequest(http.MethodGet, "/", nil)
+	r.Header.Set("X-Forwarded-For", "203.0.113.5")
+
+	w := httptest.NewRecorder()
+
+	XForwardedForToXRealIP(h).ServeHTTP(w, r)
+
+	if realIP != "203.0.113.5" {
+		t.Errorf("wanted X-Real-Ip to be filled with 203.0.113.5, got: %q", realIP)
+	}
+}


### PR DESCRIPTION
Anubis already defends `X-Forwarded-For` against forgery: `XForwardedForUpdate` flattens it to the rightmost non-private entry. But `XForwardedForToXRealIP` only fills `X-Real-Ip` **when it is unset**, so a client-forged `X-Real-Ip` survives untouched — through policy evaluation and on to the upstream target:

```console
$ curl -H 'X-Forwarded-For: 203.0.113.5' -H 'X-Real-Ip: 5.6.7.8' https://anubis.example.org/
# what the upstream target observes:
X-Forwarded-For: 203.0.113.5   # recomputed by Anubis, forgery neutralized
X-Real-Ip: 5.6.7.8             # client-supplied, passed through untouched
```

Any downstream that trusts `X-Real-Ip` (nginx `real_ip_header X-Real-IP`, PHP apps, log pipelines, further proxies) then attributes the request to an address the client picked. `X-Real-Ip` and `X-Forwarded-For` carry the same fact, but only one of them is defended.

This makes `XForwardedForToXRealIP` always derive `X-Real-Ip` from the already-recomputed `X-Forwarded-For`, and delete the header when no usable IP can be derived — a forged value can no longer reach policy checks or the upstream target.

No configuration regresses: the middleware chain runs `XForwardedForUpdate → XForwardedForToXRealIP → RemoteXRealIP → CustomRealIPHeader`, so `use-remote-address` and `custom-real-ip-header` still overwrite `X-Real-Ip` with the operator-controlled source after this change. The docs (`caveats-xff.mdx`) are updated to describe the new behavior and point operators with smarter front proxies at the existing flags.

### Testing

- `TestXForwardedForToXRealIPOverwritesForgedHeader` — forged `X-Real-Ip` is overwritten from XFF
- `TestXForwardedForToXRealIPDeletesWhenXFFUnusable` — header removed when XFF yields no usable IP
- `TestXForwardedForToXRealIPFillsWhenUnset` — previous fill-when-unset behavior preserved

Checklist:

- [x] Added a description of the changes to the `[Unreleased]` section of docs/docs/CHANGELOG.md
- [x] Added test cases to [the relevant parts of the codebase](https://github.com/TecharoHQ/anubis/blob/main/CONTRIBUTING.md)
- [x] Ran integration tests `npm run test:integration` (unsupported on Windows, please use WSL)
- [x] All of my commits have [verified signatures](https://anubis.techaro.lol/docs/developer/signed-commits)
