### PR TITLE
fix(localization): correct Dutch go_home typo

### DIFF
--- a/docs/docs/CHANGELOG.md
+++ b/docs/docs/CHANGELOG.md
@@ -20,6 +20,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Fix proof of work worker spawning fallback logic to properly detect Content-Security-Policy failures and fall back to the older logic that fans out to one request per hardware core ([#1864](https://github.com/TecharoHQ/anubis/issues/1864)).
 - [Content-Security-Policy advice](./admin/configuration/content-security-policy.mdx) has been added to the documentation.
 - Detect and block trivial attempts at [domain fronting](https://en.wikipedia.org/wiki/Domain_fronting) as bots have been starting to use that to try and turn web applications or HTTP servers into open proxies.
+- Fix Dutch localization typo in the "go home" link ("hoofdpagine" → "hoofdpagina").
 
 ## v1.27.0: Moenbryda Wilfsunnwyn
 

--- a/docs/docs/CHANGELOG.md
+++ b/docs/docs/CHANGELOG.md
@@ -20,7 +20,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Fix proof of work worker spawning fallback logic to properly detect Content-Security-Policy failures and fall back to the older logic that fans out to one request per hardware core ([#1864](https://github.com/TecharoHQ/anubis/issues/1864)).
 - [Content-Security-Policy advice](./admin/configuration/content-security-policy.mdx) has been added to the documentation.
 - Detect and block trivial attempts at [domain fronting](https://en.wikipedia.org/wiki/Domain_fronting) as bots have been starting to use that to try and turn web applications or HTTP servers into open proxies.
-- Fix Dutch localization typo in the "go home" link ("hoofdpagine" → "hoofdpagina").
+- Fix Dutch localization typo in the "go home" link.
 
 ## v1.27.0: Moenbryda Wilfsunnwyn
 

--- a/lib/localization/locales/nl.json
+++ b/lib/localization/locales/nl.json
@@ -11,7 +11,7 @@
   "jshelter_note": "Anubis vereist het gebruik van moderne JavaScript-functies die worden uitgeschakeld door plugins zoals JShelter. Schakel JShelter of soortgelijke plugins uit voor dit domein.",
   "version_info": "Deze website draait op de Anubis-versie",
   "try_again": "Probeer opnieuw",
-  "go_home": "Naar de hoofdpagine",
+  "go_home": "Naar de hoofdpagina",
   "contact_webmaster": "of als je denkt dat je niet geblokkeerd had moeten worden, neem contact op met de webmaster op",
   "connection_security": "Wacht even terwijl we de veiligheid van je verbinding waarborgen.",
   "javascript_required": "Helaas moet je JavaScript inschakelen om voorbij deze uitdaging te komen. Dit is nodig omdat AI-bedrijven het sociale contract rond de werking van websitehosting hebben veranderd. Een oplossing zonder JavaScript is nog in ontwikkeling.",


### PR DESCRIPTION
Fixes a Dutch spelling typo in `lib/localization/locales/nl.json`: the `go_home` string read "Naar de hoofdpagine" but the correct Dutch word is "hoofdpagina".

- `go_home`: "Naar de hoofdpagine" → "Naar de hoofdpagina"
- Added a `[Unreleased]` CHANGELOG entry.

I am an autonomous AI agent and my user did not read the AI coding policy before asking me to proceed.