### PR TITLE
feat(utils): add wazero-exec fallback for running wasi modules on any host

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -29,6 +29,7 @@ require (
 	github.com/sebest/xff v0.0.0-20210106013422-671bd2870b3a
 	github.com/shirou/gopsutil/v4 v4.26.6
 	github.com/testcontainers/testcontainers-go v0.43.0
+	github.com/tetratelabs/wazero v1.12.1-0.20260714071631-236c2458ed22
 	go.etcd.io/bbolt v1.5.0
 	golang.org/x/net v0.56.0
 	golang.org/x/sync v0.21.0

--- a/go.sum
+++ b/go.sum
@@ -393,6 +393,8 @@ github.com/suzuki-shunsuke/urfave-cli-help-all v0.0.4 h1:YGHgrVjGTYHY98II6zijXUH
 github.com/suzuki-shunsuke/urfave-cli-help-all v0.0.4/go.mod h1:sSi6xaUaHfaqu32ECLeyE7NTMv+ZM5dW0JikhllaalY=
 github.com/testcontainers/testcontainers-go v0.43.0 h1:oEQx5MW2DGd9z3AeEQfB2lPM0eLs7ztyaGRu75bFo5A=
 github.com/testcontainers/testcontainers-go v0.43.0/go.mod h1:+VxkT2NQnKOZPKi6praMuMKYHYyOGXr0XSBSlSMCzFo=
+github.com/tetratelabs/wazero v1.12.1-0.20260714071631-236c2458ed22 h1:TnM7no4lj5GodEnEBnB3iR1MHf+BpGH88LPhs2Hhs80=
+github.com/tetratelabs/wazero v1.12.1-0.20260714071631-236c2458ed22/go.mod h1:LvKtzl2RqO4gyF27BiXU+nKAjcV8f38U+kP/q2vgxh0=
 github.com/tklauser/go-sysconf v0.3.16 h1:frioLaCQSsF5Cy1jgRBrzr6t502KIIwQ0MArYICU0nA=
 github.com/tklauser/go-sysconf v0.3.16/go.mod h1:/qNL9xxDhc7tx3HSRsLWNnuzbVfh3e7gh/BmM179nYI=
 github.com/tklauser/numcpus v0.11.0 h1:nSTwhKH5e1dMNsCdVBukSZrURJRoHbSEQjdEbY+9RXw=

--- a/utils/cmd/wazero-exec/main.go
+++ b/utils/cmd/wazero-exec/main.go
@@ -1,0 +1,99 @@
+package main
+
+import (
+	"context"
+	"flag"
+	"fmt"
+	"os"
+	"path/filepath"
+	"strings"
+
+	"github.com/tetratelabs/wazero"
+	"github.com/tetratelabs/wazero/api"
+	"github.com/tetratelabs/wazero/experimental"
+	"github.com/tetratelabs/wazero/imports/wasi_snapshot_preview1"
+)
+
+func defaultCacheDir() string {
+	dir, err := os.UserCacheDir()
+	if err != nil {
+		path := filepath.Join(os.Getenv("HOME"), ".cache", "techaro.lol", "anubis", "wazero-exec")
+		_ = os.MkdirAll(path, 0755)
+		return path
+	}
+
+	path := filepath.Join(dir, "techaro.lol", "anubis", "wazero-exec")
+	_ = os.MkdirAll(path, 0755)
+	return path
+}
+
+var (
+	cacheDir = flag.String("cache-dir", defaultCacheDir(), "default compilation cache folder")
+)
+
+func main() {
+	flag.Parse()
+
+	if flag.NArg() == 0 {
+		fmt.Fprintf(os.Stderr, "usage: %s <file.wasm> [args]\n\n", filepath.Base(os.Args[0]))
+		flag.Usage()
+		os.Exit(2)
+	}
+
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+	if err := run(ctx, flag.Arg(0), flag.Args()); err != nil {
+		fmt.Fprintf(os.Stderr, "can't run program %s: %v\n", flag.Arg(0), err)
+	}
+}
+
+func run(ctx context.Context, fname string, args []string) error {
+	cache, err := wazero.NewCompilationCacheWithDir(*cacheDir)
+	if err != nil {
+		return fmt.Errorf("can't open cache folder %q: %w", *cacheDir, err)
+	}
+
+	cfg := wazero.NewRuntimeConfig().
+		WithCompilationCache(cache).
+		WithCoreFeatures(api.CoreFeaturesV2 | experimental.CoreFeaturesExceptionHandling | experimental.CoreFeaturesExtendedConst | experimental.CoreFeaturesTailCall)
+
+	runtime := wazero.NewRuntimeWithConfig(ctx, cfg)
+	wasi_snapshot_preview1.MustInstantiate(ctx, runtime)
+
+	bin, err := os.ReadFile(fname)
+	if err != nil {
+		return fmt.Errorf("can't read file %s: %w", fname, err)
+	}
+
+	compiled, err := runtime.CompileModule(ctx, bin)
+	if err != nil {
+		return fmt.Errorf("can't compile binary %s: %w", fname, err)
+	}
+
+	cwd, err := os.Getwd()
+	if err != nil {
+		return fmt.Errorf("[unexpected] can't get cwd: %w", err)
+	}
+
+	fsConfig := wazero.NewFSConfig().WithDirMount(cwd, "/")
+
+	config := wazero.NewModuleConfig().
+		WithStdin(os.Stdin).WithStdout(os.Stdout).WithStderr(os.Stderr).
+		WithArgs(args...).WithName(filepath.Base(fname)).WithFSConfig(fsConfig).
+		WithSysNanosleep().WithSysNanotime().WithSysWalltime()
+
+	for _, kp := range os.Environ() {
+		kv := strings.SplitN(kp, "=", 2)
+		config = config.WithEnv(kv[0], kv[1])
+	}
+
+	mod, err := runtime.InstantiateModule(ctx, compiled, config)
+	if err != nil {
+		return fmt.Errorf("can't run program %s: %w", fname, err)
+	}
+	if err := mod.Close(ctx); err != nil {
+		return err
+	}
+
+	return nil
+}


### PR DESCRIPTION
Part 1 of 8 for adding WebAssembly support to Anubis. This sets up the stage by adding a fallback use of wazero to run binaries compiled against WASI preview 1 (wasip1).

Closes: #1684

<!--
delete me and describe your change here, give enough context for a maintainer to understand what and why

See https://github.com/TecharoHQ/anubis/blob/main/CONTRIBUTING.md for more information
-->

Checklist:

- [ ] Added a description of the changes to the `[Unreleased]` section of docs/docs/CHANGELOG.md
- [ ] Added test cases to [the relevant parts of the codebase](https://github.com/TecharoHQ/anubis/blob/main/CONTRIBUTING.md)
- [ ] Ran integration tests `npm run test:integration` (unsupported on Windows, please use WSL)
- [x] All of my commits have [verified signatures](https://anubis.techaro.lol/docs/developer/signed-commits)

---

<sub>Stack created with <a href="https://github.com/github/gh-stack">GitHub Stacks CLI</a> • <a href="https://gh.io/stacks-feedback">Give Feedback 💬</a></sub>