### PR TITLE
docs: fix typo

### DIFF
--- a/docs/docs/design/how-anubis-works.mdx
+++ b/docs/docs/design/how-anubis-works.mdx
@@ -104,4 +104,4 @@ This ensures that the token has enough metadata to prove that the token is valid
 
 ## JWT signing
 
-Anubis uses an ed25519 keypair to sign the JWTs issued when challenges are passed. Anubis will generate a new ed25519 keypair every time it starts. At this time, there is no way to share this keypair between instance of Anubis, but that will be addressed in future versions.
+Anubis uses an ed25519 keypair to sign the JWTs issued when challenges are passed. Anubis will generate a new ed25519 keypair every time it starts. At this time, there is no way to share this keypair between instances of Anubis, but that will be addressed in future versions.


### PR DESCRIPTION
Fixed a typo in docs

Checklist:

- [x] All of my commits have [verified signatures](https://anubis.techaro.lol/docs/developer/signed-commits)
