### PR TITLE
fix(web): change how likelihood is calculated

### DIFF
--- a/web/js/algorithms/fast.ts
+++ b/web/js/algorithms/fast.ts
@@ -12,6 +12,7 @@ export default async function process(
   difficulty: number = 5,
   signal: AbortSignal | null = null,
   progressCallback?: ProgressCallback,
+  scale: number = 16,
   threads: number = defaultThreads(),
 ): Promise<ProcessResult> {
   console.debug("fast algo");
@@ -22,5 +23,6 @@ export default async function process(
     threads,
     signal,
     progressCallback,
+    scale,
   });
 }

--- a/web/js/algorithms/wasm.ts
+++ b/web/js/algorithms/wasm.ts
@@ -40,6 +40,7 @@ export default async function process(
   difficulty: number = 5,
   signal: AbortSignal | null = null,
   progressCallback?: ProgressCallback,
+  scale: number = 2,
   threads: number = defaultThreads(),
 ): Promise<ProcessResult> {
   const { basePrefix, version, algorithm } = options;
@@ -67,5 +68,6 @@ export default async function process(
     threads,
     signal,
     progressCallback,
+    scale,
   });
 }

--- a/web/js/algorithms/wasm2js.ts
+++ b/web/js/algorithms/wasm2js.ts
@@ -12,6 +12,7 @@ export default function process(
   difficulty: number = 5,
   signal: AbortSignal | null = null,
   progressCallback?: ProgressCallback,
+  scale: number = 2,
   threads: number = defaultThreads(),
 ): Promise<ProcessResult> {
   const { basePrefix, version, algorithm } = options;
@@ -22,5 +23,6 @@ export default function process(
     threads,
     signal,
     progressCallback,
+    scale,
   });
 }

--- a/web/js/lib/worker.ts
+++ b/web/js/lib/worker.ts
@@ -5,7 +5,7 @@ export const getHardwareConcurrency = () =>
     ? navigator.hardwareConcurrency
     : 1;
 
-export type ProgressCallback = (nonce: number | string) => void;
+export type ProgressCallback = (nonce: number | string, scale: number) => void;
 
 export interface ProcessOptions {
   basePrefix: string;
@@ -155,6 +155,7 @@ export interface RunWorkersOptions {
   message: Record<string, unknown>;
   threads: number;
   signal: AbortSignal | null;
+  scale: number;
   progressCallback?: ProgressCallback;
 }
 
@@ -182,7 +183,7 @@ export const runWorkers = async (
 
 const raceWorkers = (
   spawner: WorkerSpawner,
-  { message, threads, signal, progressCallback }: RunWorkersOptions,
+  { message, threads, signal, scale, progressCallback }: RunWorkersOptions,
 ): Promise<ProcessResult> => {
   return new Promise((resolve, reject) => {
     let workers: Worker[] = [];
@@ -252,7 +253,7 @@ const raceWorkers = (
           anyOutput = true;
 
           if (typeof event.data === "number") {
-            progressCallback?.(event.data);
+            progressCallback?.(event.data, scale);
             return;
           }
 

--- a/web/js/main.ts
+++ b/web/js/main.ts
@@ -174,7 +174,6 @@ interface OhNoesParams {
 
   let lastSpeedUpdate = 0;
   let showingApology = false;
-  const likelihood = Math.pow(16, -rules.difficulty);
 
   try {
     const t0 = Date.now();
@@ -183,7 +182,7 @@ interface OhNoesParams {
       challenge.randomData,
       rules.difficulty,
       null,
-      (iters: number) => {
+      (iters: number, scale: number) => {
         const delta = Date.now() - t0;
         // only update the speed every second so it's less visually distracting
         if (delta - lastSpeedUpdate > 1000) {
@@ -196,6 +195,7 @@ interface OhNoesParams {
         // and then slow down as things get increasingly unlikely. quadratic felt
         // the best in testing, but this may need adjustment in the future.
 
+        const likelihood = Math.pow(scale, -rules.difficulty);
         const probability = Math.pow(1 - likelihood, iters);
         const distance = (1 - Math.pow(probability, 2)) * 100;
         progress.ariaValueNow = `${distance}`;


### PR DESCRIPTION
I refactored the logic for calculating the likelihood of not finishing challenge, from being previously hardcoded to all algorithms into being hardcoded on algorithm basis.
Checklist:

- [ ] Added a description of the changes to the `[Unreleased]` section of docs/docs/CHANGELOG.md
- [ ] Added test cases to [the relevant parts of the codebase](https://github.com/TecharoHQ/anubis/blob/main/CONTRIBUTING.md)
- [ ] Ran integration tests `npm run test:integration` (unsupported on Windows, please use WSL)
- [x] All of my commits have [verified signatures](https://anubis.techaro.lol/docs/developer/signed-commits)

Refs #1924 