### PR TITLE
feat(target): supports multiple target definition

### DIFF
--- a/cmd/anubis/main.go
+++ b/cmd/anubis/main.go
@@ -26,6 +26,8 @@ import (
 	"syscall"
 	"time"
 
+	mathrand "math/rand"
+
 	"github.com/TecharoHQ/anubis"
 	"github.com/TecharoHQ/anubis/data"
 	"github.com/TecharoHQ/anubis/internal"
@@ -136,29 +138,35 @@ func parseSameSite(s string) http.SameSite {
 }
 
 func makeReverseProxy(target string, targetSNI string, targetHost string, insecureSkipVerify bool, targetDisableKeepAlive bool) (http.Handler, error) {
-	targetUri, err := url.Parse(target)
-	if err != nil {
-		return nil, fmt.Errorf("failed to parse target URL: %w", err)
-	}
-
 	transport := http.DefaultTransport.(*http.Transport).Clone()
+	targetUris := make([]*url.URL, 0, strings.Count(target, ","))
+	for _, oneTarget := range strings.Split(target, ",") {
+		oneTarget = strings.TrimSpace(oneTarget)
+		// either log and fail open, or fail closed
+		// failing close since this function doesn't do logging otherwise
+		targetUri, err := url.Parse(oneTarget)
+		if err != nil {
+			return nil, fmt.Errorf("failed to parse target URL: %w", err)
+		}
+
+		// https://github.com/oauth2-proxy/oauth2-proxy/blob/4e2100a2879ef06aea1411790327019c1a09217c/pkg/upstream/http.go#L124
+		if targetUri.Scheme == "unix" {
+			// clean path up so we don't use the socket path in proxied requests
+			addr := targetUri.Path
+			targetUri.Path = ""
+			// tell transport how to dial unix sockets
+			transport.DialContext = func(ctx context.Context, _, _ string) (net.Conn, error) {
+				dialer := net.Dialer{}
+				return dialer.DialContext(ctx, "unix", addr)
+			}
+			// tell transport how to handle the unix url scheme
+			transport.RegisterProtocol("unix", libanubis.UnixRoundTripper{Transport: transport})
+		}
+		targetUris = append(targetUris, targetUri)
+	}
 
 	if targetDisableKeepAlive {
 		transport.DisableKeepAlives = true
-	}
-
-	// https://github.com/oauth2-proxy/oauth2-proxy/blob/4e2100a2879ef06aea1411790327019c1a09217c/pkg/upstream/http.go#L124
-	if targetUri.Scheme == "unix" {
-		// clean path up so we don't use the socket path in proxied requests
-		addr := targetUri.Path
-		targetUri.Path = ""
-		// tell transport how to dial unix sockets
-		transport.DialContext = func(ctx context.Context, _, _ string) (net.Conn, error) {
-			dialer := net.Dialer{}
-			return dialer.DialContext(ctx, "unix", addr)
-		}
-		// tell transport how to handle the unix url scheme
-		transport.RegisterProtocol("unix", libanubis.UnixRoundTripper{Transport: transport})
 	}
 
 	if insecureSkipVerify || targetSNI != "" {
@@ -175,6 +183,8 @@ func makeReverseProxy(target string, targetSNI string, targetHost string, insecu
 	rp := &httputil.ReverseProxy{
 		Transport: transport,
 		Rewrite: func(r *httputil.ProxyRequest) {
+			// pick a random target amongst available targets
+			targetUri := targetUris[mathrand.Intn(len(targetUris))]
 			r.SetURL(targetUri)
 			// SetURL clears Out.Host; preserve the inbound Host, matching the
 			// previous NewSingleHostReverseProxy default.

--- a/docs/docs/CHANGELOG.md
+++ b/docs/docs/CHANGELOG.md
@@ -34,7 +34,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Rename X-Real-Ip to X-Real-I**P** in challenge metadata.
 - Fix client-supplied `X-Anubis-*` header spoofing
 - Log "challenge accepted" at INFO level when challenge is accepted, providing challenge lifecycle observability at quieter log levels than DEBUG.
-
+- Allows multiple targets, which uses (pseudo) random distribution.
 ## v1.27.0: Moenbryda Wilfsunnwyn
 
 Anubis v1.27.0 adds Windows Server support, automatically renames cookies based on settings to avoid infinite challenge loops, adds two new localizations, and more.


### PR DESCRIPTION
In a setup when multiple IPs are available for a backend, one could either:
- pick only one IP and set it as `TARGET`;
- configure a second layer of loadbalancer, set it as `TARGET` and handle multiple upstreams there. With this change, multiple `TARGET` separated by a coma; which also preserves compatibility. A pseudo-random distribution is used to fan-out between defined targets.

Notes on the PR:

I've done some basic testing in production to make sure that multiple endpoints actually receive some traffic, but I may have missed other use-cases for the target.

The semantic of a single target should not be changed by this change though.

Please point out which unit-tests need to be changed. Thanks!

Checklist:

- [x] Added a description of the changes to the `[Unreleased]` section of docs/docs/CHANGELOG.md
- [ ] Added test cases to [the relevant parts of the codebase](https://github.com/TecharoHQ/anubis/blob/main/CONTRIBUTING.md)
- [x] Ran integration tests `npm run test:integration` (unsupported on Windows, please use WSL)
- [x] All of my commits have [verified signatures](https://anubis.techaro.lol/docs/developer/signed-commits)

