### PR TITLE
fix(lib): Clarify getChallenge error log

### DIFF
--- a/docs/docs/CHANGELOG.md
+++ b/docs/docs/CHANGELOG.md
@@ -34,6 +34,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Rename X-Real-Ip to X-Real-I**P** in challenge metadata.
 - Fix client-supplied `X-Anubis-*` header spoofing
 - Log "challenge accepted" at INFO level when challenge is accepted, providing challenge lifecycle observability at quieter log levels than DEBUG.
+- Clarify getChallenge failure response and cite related log entry. 
 
 ## v1.27.0: Moenbryda Wilfsunnwyn
 

--- a/lib/anubis.go
+++ b/lib/anubis.go
@@ -612,11 +612,7 @@ func (s *Server) PassChallenge(w http.ResponseWriter, r *http.Request) {
 	chall, err := s.getChallenge(r)
 	if err != nil {
 		lg.ErrorContext(r.Context(), "getChallenge failed", "err", err)
-		algorithm := "unknown"
-		if rule.Challenge != nil {
-			algorithm = rule.Challenge.Algorithm
-		}
-		s.respondWithError(w, r, fmt.Sprintf("%s: %s", localizer.T("internal_server_error"), algorithm), makeCode(err))
+		s.respondWithError(w, r, fmt.Sprintf("%s: %s", localizer.T("internal_server_error"), "getChallenge failed"), makeCode(err))
 		return
 	}
 


### PR DESCRIPTION
Respond to the client with a useful error message. The "getChallenge failed" message is logged on the line prior. The encoded text is unchanged.

Checklist:

- [X] Added a description of the changes to the `[Unreleased]` section of docs/docs/CHANGELOG.md
- [N/A] Added test cases to [the relevant parts of the codebase](https://github.com/TecharoHQ/anubis/blob/main/CONTRIBUTING.md)
- [N/A] Ran integration tests `npm run test:integration` (unsupported on Windows, please use WSL)
- [X] All of my commits have [verified signatures](https://anubis.techaro.lol/docs/developer/signed-commits)
