### PR TITLE
fix(lib): validate subrequest authentication redirects consistently

### DIFF
--- a/docs/docs/CHANGELOG.md
+++ b/docs/docs/CHANGELOG.md
@@ -35,6 +35,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Fix client-supplied `X-Anubis-*` header spoofing
 - Log "challenge accepted" at INFO level when challenge is accepted, providing challenge lifecycle observability at quieter log levels than DEBUG.
 - Clarify getChallenge failure response and cite related log entry. 
+- Share redirect validation between challenge completion and subrequest authentication. Reject ambiguous URL forms before checking allowed domains.
 
 ## v1.27.0: Moenbryda Wilfsunnwyn
 

--- a/lib/anubis.go
+++ b/lib/anubis.go
@@ -11,7 +11,6 @@ import (
 	"log/slog"
 	"net"
 	"net/http"
-	"net/url"
 	"strconv"
 	"strings"
 	"time"
@@ -557,19 +556,12 @@ func (s *Server) PassChallenge(w http.ResponseWriter, r *http.Request) {
 	localizer := localization.GetLocalizer(r)
 
 	redir := r.FormValue("redir")
-	redirURL, err := url.ParseRequestURI(redir)
-	if err != nil {
-		lg.ErrorContext(r.Context(), "invalid redirect", "err", err)
-		s.respondWithStatus(w, r, localizer.T("invalid_redirect"), makeCode(err), http.StatusBadRequest)
-		return
+	redirURL, err := s.validateRedirect(redir)
+	if err == nil && (redir == "" || (redirURL.Scheme == "" && !strings.HasPrefix(redir, "/"))) {
+		err = ErrInvalidRedirect
 	}
-
-	switch redirURL.Scheme {
-	case "", "http", "https":
-		// allowed
-	default:
-		lg.ErrorContext(r.Context(), "XSS attempt blocked, invalid redirect scheme", "scheme", redirURL.Scheme)
-		s.respondWithStatus(w, r, localizer.T("invalid_redirect"), "", http.StatusBadRequest)
+	if err != nil {
+		s.rejectRedirect(w, r, err)
 		return
 	}
 
@@ -589,17 +581,6 @@ func (s *Server) PassChallenge(w http.ResponseWriter, r *http.Request) {
 
 	// used by the path checker rule
 	r.URL = redirURL
-
-	urlParsed, err := r.URL.Parse(redir)
-	if err != nil {
-		s.respondWithError(w, r, localizer.T("redirect_not_parseable"), makeCode(err))
-		return
-	}
-	if (len(urlParsed.Host) > 0 && len(s.opts.RedirectDomains) != 0 && !matchRedirectDomain(s.opts.RedirectDomains, urlParsed.Host)) || urlParsed.Host != r.URL.Host {
-		lg.DebugContext(r.Context(), "domain not allowed", "domain", urlParsed.Host)
-		s.respondWithError(w, r, localizer.T("redirect_domain_not_allowed"), "")
-		return
-	}
 
 	cr, rule, err := s.check(r, lg)
 	if err != nil {

--- a/lib/anubis_test.go
+++ b/lib/anubis_test.go
@@ -1176,8 +1176,9 @@ func TestPassChallengeNilRuleChallengeFallback(t *testing.T) {
 	pol := loadPolicies(t, "testdata/zero_difficulty.yaml", 0)
 
 	srv := spawnAnubis(t, Options{
-		Next:   http.NewServeMux(),
-		Policy: pol,
+		Next:            http.NewServeMux(),
+		Policy:          pol,
+		RedirectDomains: []string{"allowed.example"},
 	})
 
 	allowThreshold, err := policy.ParsedThresholdFromConfig(config.Threshold{
@@ -1216,12 +1217,34 @@ func TestPassChallengeNilRuleChallengeFallback(t *testing.T) {
 	req.Header.Set("User-Agent", "NilChallengeTester/1.0")
 	req.AddCookie(&http.Cookie{Name: srv.cookieName(anubis.TestCookieName), Value: chall.ID})
 
+	for _, target := range []string{"https:///evil.com/", "https://evil.com/", "//evil.com", `/\evil.com`} {
+		badReq := req.Clone(req.Context())
+		badQuery := badReq.URL.Query()
+		badQuery.Set("redir", target)
+		badReq.URL.RawQuery = badQuery.Encode()
+		badResponse := httptest.NewRecorder()
+		srv.PassChallenge(badResponse, badReq)
+		if badResponse.Code != http.StatusBadRequest || badResponse.Header().Get("Location") != "" || len(badResponse.Result().Cookies()) != 0 {
+			t.Fatalf("invalid target %q: got %d, %v", target, badResponse.Code, badResponse.Header())
+		}
+		stored, err := j.Get(req.Context(), "challenge:"+chall.ID)
+		if err != nil || stored.Spent {
+			t.Fatalf("invalid redirect changed challenge state: spent=%v, err=%v", stored.Spent, err)
+		}
+	}
+	const target = "https://allowed.example/safe%2Fpath?q=%2F%2Fevil.com#fragment"
+	q.Set("redir", target)
+	req.URL.RawQuery = q.Encode()
+
 	rr := httptest.NewRecorder()
 
 	srv.PassChallenge(rr, req)
 
 	if rr.Code != http.StatusFound {
 		t.Fatalf("expected redirect when validating challenge, got %d", rr.Code)
+	}
+	if rr.Header().Get("Location") != target {
+		t.Fatalf("unexpected Location: %q", rr.Header().Get("Location"))
 	}
 }
 

--- a/lib/http.go
+++ b/lib/http.go
@@ -54,6 +54,57 @@ func matchRedirectDomain(allowed []string, host string) bool {
 	return false
 }
 
+var (
+	ErrInvalidRedirect          = errors.New("invalid redirect")
+	ErrRedirectDomainNotAllowed = errors.New("redirect domain not allowed")
+)
+
+// validateRedirect validates the form-decoded target without changing its escaping.
+func (s *Server) validateRedirect(redir string) (*url.URL, error) {
+	if strings.HasPrefix(redir, " ") || strings.ContainsAny(redir, "\\") {
+		return nil, ErrInvalidRedirect
+	}
+	for _, c := range redir {
+		if c < 0x20 || c == 0x7f {
+			return nil, ErrInvalidRedirect
+		}
+	}
+	u, err := url.Parse(redir)
+	if err != nil {
+		return nil, fmt.Errorf("%w: %w", ErrInvalidRedirect, err)
+	}
+	if u.Opaque != "" {
+		return nil, ErrInvalidRedirect
+	}
+	switch u.Scheme {
+	case "":
+		if u.Host != "" || strings.HasPrefix(u.Path, "//") || strings.ContainsAny(u.Path, "\\") {
+			return nil, ErrInvalidRedirect
+		}
+	case "http", "https":
+		if u.Hostname() == "" {
+			return nil, ErrInvalidRedirect
+		}
+	default:
+		return nil, ErrInvalidRedirect
+	}
+	if u.Host != "" && len(s.opts.RedirectDomains) != 0 && !matchRedirectDomain(s.opts.RedirectDomains, u.Host) {
+		return nil, ErrRedirectDomainNotAllowed
+	}
+	return u, nil
+}
+
+func (s *Server) rejectRedirect(w http.ResponseWriter, r *http.Request, err error) {
+	lg, _ := s.getRequestLogger(r)
+	localizer := localization.GetLocalizer(r)
+	message := "invalid_redirect"
+	if errors.Is(err, ErrRedirectDomainNotAllowed) {
+		message = "redirect_domain_not_allowed"
+	}
+	lg.DebugContext(r.Context(), "invalid redirect", "err", err)
+	s.respondWithStatus(w, r, localizer.T(message), "", http.StatusBadRequest)
+}
+
 type CookieOpts struct {
 	Value  string
 	Host   string
@@ -424,37 +475,8 @@ func (s *Server) ServeHTTPNext(w http.ResponseWriter, r *http.Request) {
 		localizer := localization.GetLocalizer(r)
 
 		redir := r.FormValue("redir")
-		urlParsed, err := url.Parse(redir)
-		if err != nil {
-			s.respondWithStatus(w, r, localizer.T("redirect_not_parseable"), makeCode(err), http.StatusBadRequest)
-			return
-		}
-
-		if urlParsed.Opaque != "" || (urlParsed.Scheme == "" && strings.HasPrefix(redir, "//")) {
-			s.respondWithStatus(w, r, localizer.T("invalid_redirect"), "", http.StatusBadRequest)
-			return
-		}
-
-		// validate URL scheme to prevent javascript:, data:, file:, tel:, etc.
-		switch urlParsed.Scheme {
-		case "", "http", "https":
-			// allowed: empty scheme means relative URL
-		default:
-			lg, _ := s.getRequestLogger(r)
-			lg.WarnContext(r.Context(), "XSS attempt blocked, invalid redirect scheme", "scheme", urlParsed.Scheme, "redir", redir)
-			s.respondWithStatus(w, r, localizer.T("invalid_redirect"), "", http.StatusBadRequest)
-			return
-		}
-
-		hostNotAllowed := len(urlParsed.Host) > 0 &&
-			len(s.opts.RedirectDomains) != 0 &&
-			!matchRedirectDomain(s.opts.RedirectDomains, urlParsed.Host)
-		hostMismatch := r.URL.Host != "" && urlParsed.Host != "" && urlParsed.Host != r.URL.Host
-
-		if hostNotAllowed || hostMismatch {
-			lg, _ := s.getRequestLogger(r)
-			lg.DebugContext(r.Context(), "domain not allowed", "domain", urlParsed.Host)
-			s.respondWithStatus(w, r, localizer.T("redirect_domain_not_allowed"), makeCode(err), http.StatusBadRequest)
+		if _, err := s.validateRedirect(redir); err != nil {
+			s.rejectRedirect(w, r, err)
 			return
 		}
 

--- a/lib/redirect_security_test.go
+++ b/lib/redirect_security_test.go
@@ -1,6 +1,10 @@
 package lib
 
+// URL-encoded separators adjacent to the test hostname produce these tokens.
+// cspell:ignore Fevil Cevil
+
 import (
+	"errors"
 	"log/slog"
 	"net/http"
 	"net/http/httptest"
@@ -8,6 +12,7 @@ import (
 	"strings"
 	"testing"
 
+	"github.com/TecharoHQ/anubis"
 	"github.com/TecharoHQ/anubis/lib/policy"
 )
 
@@ -191,7 +196,7 @@ func TestRedirectSecurity(t *testing.T) {
 	s := &Server{
 		opts: Options{
 			PublicUrl:       "https://anubis.example.com",
-			RedirectDomains: []string{},
+			RedirectDomains: []string{"example.com"},
 		},
 		logger: slog.Default(),
 		policy: &policy.ParsedConfig{},
@@ -241,7 +246,6 @@ func TestRedirectSecurity(t *testing.T) {
 			case "serveHTTPNext":
 				req := httptest.NewRequest("GET", "/.within.website/?redir="+url.QueryEscape(tt.redirParam), nil)
 				req.Host = tt.reqHost
-				req.URL.Host = tt.reqHost
 				rr := httptest.NewRecorder()
 
 				s.ServeHTTPNext(rr, req)
@@ -291,5 +295,94 @@ func TestRedirectSecurity(t *testing.T) {
 				}
 			}
 		})
+	}
+}
+
+func TestValidateRedirect(t *testing.T) {
+	s := &Server{opts: Options{RedirectDomains: []string{"allowed.example", "*.allowed.example", "allowed.example:8443"}}}
+	for _, tt := range []struct {
+		target string
+		want   error
+	}{
+		{"/safe/path", nil},
+		{"relative/path", nil},
+		{"/safe%2Fpath?q=%2F%2Fevil.com#fragment", nil},
+		{"https://ALLOWED.example/path", nil},
+		{"http://sub.allowed.example/", nil},
+		{"https://allowed.example:8443/", nil},
+		{"https://allowed.example:9443/", ErrRedirectDomainNotAllowed},
+		{"https://evil.com/", ErrRedirectDomainNotAllowed},
+		{"https://allowed.example@evil.com/", ErrRedirectDomainNotAllowed},
+		{"https:///evil.com/", ErrInvalidRedirect},
+		{"http:/evil.com/", ErrInvalidRedirect},
+		{"https:evil.com", ErrInvalidRedirect},
+		{"//evil.com", ErrInvalidRedirect},
+		{"//allowed.example", ErrInvalidRedirect},
+		{"///evil.com", ErrInvalidRedirect},
+		{"////evil.com", ErrInvalidRedirect},
+		{"/%2Fevil.com", ErrInvalidRedirect},
+		{"/%2F%2Fevil.com", ErrInvalidRedirect},
+		{"/%5Cevil.com", ErrInvalidRedirect},
+		{`/\evil.com`, ErrInvalidRedirect},
+		{`https://allowed.example\@evil.com/`, ErrInvalidRedirect},
+		{" https://evil.com/", ErrInvalidRedirect},
+		{"/\tevil.com", ErrInvalidRedirect},
+		{"javascript:alert(1)", ErrInvalidRedirect},
+		{"data:text/plain,test", ErrInvalidRedirect},
+		{"file:///etc/passwd", ErrInvalidRedirect},
+		{"/%zz", ErrInvalidRedirect},
+	} {
+		t.Run(tt.target, func(t *testing.T) {
+			_, err := s.validateRedirect(tt.target)
+			if !errors.Is(err, tt.want) {
+				t.Fatalf("validateRedirect(%q) = %v, want %v", tt.target, err, tt.want)
+			}
+		})
+	}
+}
+
+func TestRedirectHandlersRejectAmbiguousTargets(t *testing.T) {
+	// These are wire query strings, not already decoded form values.
+	for _, query := range []string{
+		"https:///evil.com/", "http:/evil.com/", "https:evil.com",
+		"//evil.com", "/%2Fevil.com", `/\evil.com`, "///evil.com",
+		"////evil.com", "/%2F%2Fevil.com", "/%252Fevil.com",
+		"/%255Cevil.com", "%20https://evil.com", "/%09/evil.com",
+		"javascript:alert(1)", "//allowed.example",
+	} {
+		t.Run(query, func(t *testing.T) {
+			for _, domains := range [][]string{nil, {"allowed.example"}} {
+				s := &Server{opts: Options{RedirectDomains: domains}, logger: slog.Default(), policy: &policy.ParsedConfig{}}
+				for name, handler := range map[string]http.HandlerFunc{"next": s.ServeHTTPNext, "pass": s.PassChallenge} {
+					for _, cookie := range []bool{false, true} {
+						req := httptest.NewRequest(http.MethodGet, "/.within.website/?redir="+query, nil)
+						if cookie {
+							req.AddCookie(&http.Cookie{Name: s.cookieName(anubis.TestCookieName), Value: "test"})
+						}
+						rr := httptest.NewRecorder()
+						handler(rr, req)
+						if rr.Code != http.StatusBadRequest || rr.Header().Get("Location") != "" || len(rr.Result().Cookies()) != 0 {
+							t.Errorf("%s: expected 400 without redirect or cookies, got %d, %v", name, rr.Code, rr.Header())
+						}
+					}
+				}
+			}
+		})
+	}
+}
+
+func TestRedirectAllowedDestination(t *testing.T) {
+	for _, domains := range [][]string{nil, {"allowed.example"}} {
+		s := &Server{opts: Options{RedirectDomains: domains}, logger: slog.Default(), policy: &policy.ParsedConfig{}}
+		for _, base := range []string{"", "https://auth.example"} {
+			for _, target := range []string{"https://allowed.example/safe%2Fpath?q=%2F%2Fevil.com#fragment", "/safe%2Fpath?q=%2F%2Fevil.com#fragment"} {
+				req := httptest.NewRequest(http.MethodGet, base+"/.within.website/?redir="+url.QueryEscape(target), nil)
+				rr := httptest.NewRecorder()
+				s.ServeHTTPNext(rr, req)
+				if rr.Code != http.StatusFound || rr.Header().Get("Location") != target {
+					t.Errorf("target %q: got %d, Location %q", target, rr.Code, rr.Header().Get("Location"))
+				}
+			}
+		}
 	}
 }


### PR DESCRIPTION
Share redirect validation between challenge completion and subrequest authentication. Reject ambiguous URL forms before checking allowed domains and cover redirect bypasses and challenge state in regression tests.

Assisted-by: GPT-6 via Codex

* This is a follow-up for https://github.com/TecharoHQ/anubis/security/advisories/GHSA-cf57-c578-7jvv with points I raised there back then
* It should address https://github.com/TecharoHQ/anubis/security/advisories/GHSA-rqcr-jcxp-xrwr (I don't have access to this one, but the issue was originally reported to us and I pointed the reporter to your repo)


Checklist:

- [x] Added a description of the changes to the `[Unreleased]` section of docs/docs/CHANGELOG.md
- [x] Added test cases to [the relevant parts of the codebase](https://github.com/TecharoHQ/anubis/blob/main/CONTRIBUTING.md)
- [x] Ran integration tests `npm run test:integration` (unsupported on Windows, please use WSL)
- [x] All of my commits have [verified signatures](https://anubis.techaro.lol/docs/developer/signed-commits)
